### PR TITLE
feat: connect extension to production backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,9 +44,11 @@ Deployment steps and security practices are described in [`docs/deployment.md`](
 
 ### Browser Extension
 The extension source resides in the `extension/` directory. Load this folder as
-an unpacked extension from Chrome's Extensions page (Developer Mode). Configure
-the backend URL and API token through the popup before capturing
-conversations.
+an unpacked extension from Chrome's Extensions page (Developer Mode). Choose the
+desired environment (production or development) and set the API token through
+the popup before capturing conversations. See
+[`docs/extension-setup.md`](docs/extension-setup.md) for configuration and
+testing instructions.
 
 ## Contributing Guidelines
 *Contribution instructions forthcoming. Stay tuned!*

--- a/docs/extension-setup.md
+++ b/docs/extension-setup.md
@@ -1,0 +1,38 @@
+# Extension Setup Guide
+
+## CORS Configuration
+Ensure the backend allows requests from the extension by setting the following
+in Django settings:
+```python
+CORS_ALLOWED_ORIGINS = [
+    'http://localhost:8000',
+    'https://master-mind-ai.onrender.com',
+    'chrome-extension://<extension-id>'
+]
+```
+Replace `<extension-id>` with the generated extension ID once the extension is
+loaded in Chrome.
+
+## Retrieve Extension ID
+1. Load the `extension/` folder as an unpacked extension in Chrome.
+2. On the extensions page, locate "Master Mind AI" and copy its ID.
+3. Use this ID in backend CORS settings and any API configuration as needed.
+
+## Render Environment Variables
+Update `API_BASE_URL` and related secrets in Render dashboard:
+- `API_BASE_URL` → `https://master-mind-ai.onrender.com`
+- Any additional tokens required by the extension or backend.
+
+## Testing Procedures
+- Run Jest tests for the extension:
+  ```bash
+  cd extension
+  npm test
+  ```
+- Verify health endpoint:
+  ```bash
+  curl https://master-mind-ai.onrender.com/api/v1/health/
+  ```
+- Load the extension and confirm the popup shows a connected status.
+- Trigger a conversation capture and check for successful API responses in the
+  console.

--- a/extension/api.js
+++ b/extension/api.js
@@ -1,0 +1,57 @@
+import { getSettings } from './config.js';
+
+class APIClient {
+  async request(path, { method = 'GET', body } = {}) {
+    const { apiBaseUrl, apiToken } = await getSettings();
+    const url = `${apiBaseUrl}${path}`;
+    const headers = { 'Content-Type': 'application/json' };
+    if (apiToken) headers['Authorization'] = `Bearer ${apiToken}`;
+
+    for (let attempt = 0; attempt < 3; attempt++) {
+      try {
+        const res = await fetch(url, { method, headers, body });
+        if (res.status === 429) {
+          const wait = 2 ** attempt * 1000;
+          await new Promise(r => setTimeout(r, wait));
+          continue;
+        }
+        if (!res.ok) {
+          const text = await res.text();
+          throw new Error(text || res.statusText);
+        }
+        return res.status === 204 ? null : await res.json();
+      } catch (err) {
+        if (attempt === 2) throw err;
+        const wait = 2 ** attempt * 1000;
+        await new Promise(r => setTimeout(r, wait));
+      }
+    }
+  }
+
+  healthCheck() {
+    return this.request('/api/v1/health/');
+  }
+
+  saveConversation(payload) {
+    return this.request('/api/v1/conversations/', {
+      method: 'POST',
+      body: JSON.stringify(payload)
+    });
+  }
+
+  enhancePrompt(payload) {
+    return this.request('/api/v1/prompts/enhance/', {
+      method: 'POST',
+      body: JSON.stringify(payload)
+    });
+  }
+
+  searchMemory(payload) {
+    return this.request('/api/v1/conversations/search/', {
+      method: 'POST',
+      body: JSON.stringify(payload)
+    });
+  }
+}
+
+export const apiClient = new APIClient();

--- a/extension/background.js
+++ b/extension/background.js
@@ -1,58 +1,53 @@
-const API = {
-  store: '/api/v1/conversations/',
-  search: '/api/v1/conversations/search/'
-};
+import { apiClient } from './api.js';
 
-async function getSettings() {
-  return new Promise(resolve => {
-    chrome.storage.sync.get(
-      { apiBaseUrl: 'http://localhost:8000', apiToken: '' },
-      resolve
-    );
-  });
-}
+let healthStatus = { ok: false };
 
-async function apiCall(path, payload) {
-  const { apiBaseUrl, apiToken } = await getSettings();
-  const url = `${apiBaseUrl}${path}`;
-  const headers = { 'Content-Type': 'application/json' };
-  if (apiToken) headers['Authorization'] = `Bearer ${apiToken}`;
-
+async function checkHealth() {
   for (let attempt = 0; attempt < 3; attempt++) {
     try {
-      const res = await fetch(url, {
-        method: 'POST',
-        headers,
-        body: JSON.stringify(payload)
-      });
-      if (res.status === 429) {
-        const wait = (attempt + 1) * 1000;
-        await new Promise(r => setTimeout(r, wait));
-        continue;
-      }
-      if (!res.ok) throw new Error(`API ${res.status}`);
-      return await res.json();
-    } catch (err) {
-      if (attempt === 2) throw err;
-      const wait = (attempt + 1) * 1000;
+      await apiClient.healthCheck();
+      healthStatus = { ok: true };
+      return;
+    } catch (error) {
+      healthStatus = { ok: false, error: error.message };
+      const wait = 2 ** attempt * 1000;
       await new Promise(r => setTimeout(r, wait));
     }
   }
 }
 
+checkHealth();
+chrome.runtime.onStartup.addListener(checkHealth);
+
 chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
+  if (msg.type === 'health-check') {
+    checkHealth().then(() => sendResponse(healthStatus));
+    return true;
+  }
+  if (msg.type === 'health') {
+    sendResponse(healthStatus);
+    return true;
+  }
+
   if (msg.type === 'conversation') {
-    apiCall(API.store, {
-      platform: msg.platform,
-      messages: msg.messages
-    })
+    apiClient
+      .saveConversation({ platform: msg.platform, messages: msg.messages })
+      .then(data => sendResponse({ success: true, data }))
+      .catch(error => sendResponse({ success: false, error: error.message }));
+    return true;
+  }
+
+  if (msg.type === 'enhance') {
+    apiClient
+      .enhancePrompt({ prompt: msg.prompt })
       .then(data => sendResponse({ success: true, data }))
       .catch(error => sendResponse({ success: false, error: error.message }));
     return true;
   }
 
   if (msg.type === 'search') {
-    apiCall(API.search, { query: msg.query })
+    apiClient
+      .searchMemory({ query: msg.query })
       .then(data => sendResponse({ success: true, data }))
       .catch(error => sendResponse({ success: false, error: error.message }));
     return true;

--- a/extension/config.js
+++ b/extension/config.js
@@ -1,0 +1,25 @@
+export const ENVIRONMENTS = {
+  development: 'http://localhost:8000',
+  production: 'https://master-mind-ai.onrender.com'
+};
+
+export function getSettings() {
+  return new Promise(resolve => {
+    chrome.storage.sync.get(
+      { environment: 'production', apiToken: '' },
+      ({ environment, apiToken }) => {
+        resolve({
+          apiBaseUrl: ENVIRONMENTS[environment] || ENVIRONMENTS.production,
+          apiToken,
+          environment
+        });
+      }
+    );
+  });
+}
+
+export function setSettings({ environment, apiToken }) {
+  return new Promise(resolve => {
+    chrome.storage.sync.set({ environment, apiToken }, resolve);
+  });
+}

--- a/extension/content/chatgpt.js
+++ b/extension/content/chatgpt.js
@@ -10,7 +10,14 @@ function getMessages() {
 const sendUpdates = debounce(() => {
   const messages = getMessages();
   if (messages.length) {
-    chrome.runtime.sendMessage({ type: 'conversation', platform, messages });
+    chrome.runtime.sendMessage(
+      { type: 'conversation', platform, messages },
+      res => {
+        if (!res?.success) {
+          console.error('Failed to save conversation', res?.error);
+        }
+      }
+    );
   }
 });
 

--- a/extension/content/claude.js
+++ b/extension/content/claude.js
@@ -10,7 +10,14 @@ function getMessages() {
 const sendUpdates = debounce(() => {
   const messages = getMessages();
   if (messages.length) {
-    chrome.runtime.sendMessage({ type: 'conversation', platform, messages });
+    chrome.runtime.sendMessage(
+      { type: 'conversation', platform, messages },
+      res => {
+        if (!res?.success) {
+          console.error('Failed to save conversation', res?.error);
+        }
+      }
+    );
   }
 });
 

--- a/extension/content/gemini.js
+++ b/extension/content/gemini.js
@@ -10,7 +10,14 @@ function getMessages() {
 const sendUpdates = debounce(() => {
   const messages = getMessages();
   if (messages.length) {
-    chrome.runtime.sendMessage({ type: 'conversation', platform, messages });
+    chrome.runtime.sendMessage(
+      { type: 'conversation', platform, messages },
+      res => {
+        if (!res?.success) {
+          console.error('Failed to save conversation', res?.error);
+        }
+      }
+    );
   }
 });
 

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -8,7 +8,8 @@
     "https://chat.openai.com/*",
     "https://claude.ai/*",
     "https://gemini.google.com/*",
-    "http://localhost:8000/*"
+    "http://localhost:8000/*",
+    "https://master-mind-ai.onrender.com/*"
   ],
   "background": {
     "service_worker": "background.js",

--- a/extension/popup.html
+++ b/extension/popup.html
@@ -7,13 +7,17 @@
 </head>
 <body>
   <h1>Master Mind AI</h1>
-  <label>API Base URL
-    <input id="baseUrl" type="text" placeholder="http://localhost:8000" />
+  <label>Environment
+    <select id="environment">
+      <option value="production">Production</option>
+      <option value="development">Development</option>
+    </select>
   </label>
   <label>API Token
     <input id="token" type="text" placeholder="token" />
   </label>
   <button id="save">Save</button>
+  <div id="connection"></div>
   <div id="status"></div>
   <script type="module" src="popup.js"></script>
 </body>


### PR DESCRIPTION
## Summary
- add API client and environment config for production and development
- run health checks with retry and expose status in the extension popup
- document extension setup and add production host permissions

## Testing
- `npm test`
- `curl -sS https://master-mind-ai.onrender.com/api/v1/health/` *(fails: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68c4ededf0c88324896dcc9da004f4d0