### PR TITLE
Add health check endpoint

### DIFF
--- a/backend/api/urls.py
+++ b/backend/api/urls.py
@@ -1,11 +1,17 @@
 """API URL routing."""
+from django.urls import path
 from rest_framework.routers import DefaultRouter
 
-from .views import ConversationViewSet, ProjectViewSet, UserProfileViewSet
+from .views import (
+    ConversationViewSet,
+    ProjectViewSet,
+    UserProfileViewSet,
+    health_check,
+)
 
 router = DefaultRouter()
 router.register(r"users", UserProfileViewSet, basename="userprofile")
 router.register(r"projects", ProjectViewSet, basename="project")
 router.register(r"conversations", ConversationViewSet, basename="conversation")
 
-urlpatterns = router.urls
+urlpatterns = [path("health/", health_check, name="health_check")] + router.urls

--- a/backend/api/views.py
+++ b/backend/api/views.py
@@ -3,6 +3,10 @@ from __future__ import annotations
 
 import logging
 
+from django.db import DatabaseError, connection
+from django.http import JsonResponse
+from django.views.decorators.csrf import csrf_exempt
+from django.views.decorators.http import require_http_methods
 from rest_framework import status, viewsets
 from rest_framework.decorators import action
 from rest_framework.response import Response
@@ -12,6 +16,22 @@ from .serializers import ConversationSerializer, ProjectSerializer, UserProfileS
 from .services.memory_service import MemoryService
 
 logger = logging.getLogger(__name__)
+
+
+@csrf_exempt
+@require_http_methods(["GET"])
+def health_check(_request) -> JsonResponse:
+    """Health check endpoint for monitoring and Chrome extension."""
+    try:
+        with connection.cursor() as cursor:
+            cursor.execute("SELECT 1")
+        return JsonResponse(
+            {"status": "ok", "service": "master-mind-ai", "database": "connected"}
+        )
+    except DatabaseError:
+        return JsonResponse(
+            {"status": "error", "error": "connection failed"}, status=500
+        )
 
 
 class UserProfileViewSet(viewsets.ModelViewSet):

--- a/backend/mastermind/urls.py
+++ b/backend/mastermind/urls.py
@@ -1,26 +1,11 @@
 """URL configuration for the Master Mind AI project."""
-import logging
-
 from django.contrib import admin
-from django.db import connections, DatabaseError
-from django.http import JsonResponse
 from django.urls import include, path
 
-logger = logging.getLogger(__name__)
-
-
-def health(_request):
-    """Health endpoint with database connectivity check."""
-    try:
-        with connections["default"].cursor() as cursor:
-            cursor.execute("SELECT 1")
-        return JsonResponse({"status": "ok"})
-    except DatabaseError:
-        logger.exception("Database connectivity check failed")
-        return JsonResponse({"status": "error"}, status=500)
+from api.views import health_check
 
 urlpatterns = [
-    path("", health, name="health"),
+    path("", health_check, name="health"),
     path("admin/", admin.site.urls),
     path("api/v1/", include("api.urls")),
 ]

--- a/backend/tests/test_health_endpoint.py
+++ b/backend/tests/test_health_endpoint.py
@@ -1,0 +1,26 @@
+"""Tests for health check endpoint."""
+from unittest.mock import patch
+
+from django.db import DatabaseError
+from django.test import TestCase
+
+
+class HealthEndpointTests(TestCase):
+    """Validate health check responses."""
+
+    def test_health_check_success(self) -> None:
+        response = self.client.get("/api/v1/health/")
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            response.json(),
+            {"status": "ok", "service": "master-mind-ai", "database": "connected"},
+        )
+
+    @patch("api.views.connection.cursor", side_effect=DatabaseError("fail"))
+    def test_health_check_database_error(self, _mock_cursor) -> None:
+        response = self.client.get("/api/v1/health/")
+        self.assertEqual(response.status_code, 500)
+        self.assertEqual(
+            response.json(), {"status": "error", "error": "connection failed"}
+        )
+

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -3,6 +3,7 @@
 ## Backend
 - Install dependencies: `pip install -r backend/requirements.txt`
 - Run tests: `cd backend && pytest`
+- Verify health endpoint: `curl http://localhost:8000/api/v1/health/`
 
 ## Browser Extension
 - Install Node dependencies: `cd extension && npm install`


### PR DESCRIPTION
## Summary
- add `/api/v1/health/` endpoint with database connectivity check
- route root health check through shared view
- document verifying backend health
- cover endpoint with tests

## Testing
- `SECRET_KEY=test DEBUG=true DATABASE_URL=sqlite:///:memory: pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c50074655883248c434cbc8866f15b