### PR TITLE
feat: self-contained Claude content script

### DIFF
--- a/extension/content/claude.js
+++ b/extension/content/claude.js
@@ -1,27 +1,128 @@
-import { debounce } from './utils.js';
+/**
+ * Content script for capturing conversations on claude.ai and
+ * sending them to the Master Mind AI backend. The script is
+ * self-contained and avoids external module imports so it can run
+ * as a plain content script in any Chromium-based browser.
+ */
 
-const platform = 'claude';
+// Configuration for backend communication and DOM selectors
+const CONFIG = {
+  API_URL: 'https://master-mind-ai.onrender.com/api/v1/conversations/',
+  SELECTORS: {
+    // Root container for the conversation
+    container: 'main',
+    // Individual message nodes within the conversation
+    message: 'main [data-message-id]'
+  },
+  RETRY: {
+    attempts: 3,
+    baseDelay: 1000 // milliseconds
+  }
+};
 
-function getMessages() {
-  const nodes = document.querySelectorAll('main [data-message-id]');
-  return Array.from(nodes, n => n.innerText.trim()).filter(Boolean);
+// Tracks state for duplicate detection
+const state = {
+  lastHash: ''
+};
+
+/**
+ * Simple debounce implementation to throttle rapid DOM updates.
+ * @param {Function} fn - function to debounce
+ * @param {number} wait - delay in milliseconds
+ * @returns {Function}
+ */
+function debounce(fn, wait = 1000) {
+  let t;
+  return (...args) => {
+    clearTimeout(t);
+    t = setTimeout(() => fn.apply(null, args), wait);
+  };
 }
 
-const sendUpdates = debounce(() => {
-  const messages = getMessages();
-  if (messages.length) {
-    chrome.runtime.sendMessage(
-      { type: 'conversation', platform, messages },
-      res => {
-        if (!res?.success) {
-          console.error('Failed to save conversation', res?.error);
-        }
-      }
-    );
+/**
+ * Extracts all visible messages from the page.
+ * @returns {{ platform: string, messages: string[] }}
+ */
+function captureConversation() {
+  const nodes = document.querySelectorAll(CONFIG.SELECTORS.message);
+  const messages = Array.from(nodes, node => node.innerText.trim()).filter(Boolean);
+  return { platform: 'claude', messages };
+}
+
+/**
+ * Sends conversation data to the backend with basic retry logic.
+ * @param {Object} payload - data to send
+ * @param {number} attempt - current retry attempt
+ * @returns {Promise<void>}
+ */
+async function sendToAPI(payload, attempt = 0) {
+  try {
+    const res = await fetch(CONFIG.API_URL, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload)
+    });
+
+    if (!res.ok) {
+      throw new Error(`HTTP ${res.status}`);
+    }
+
+    // Consume response to avoid memory leaks
+    await res.json();
+  } catch (error) {
+    if (attempt + 1 < CONFIG.RETRY.attempts) {
+      const wait = CONFIG.RETRY.baseDelay * 2 ** attempt;
+      return new Promise(resolve =>
+        setTimeout(() => resolve(sendToAPI(payload, attempt + 1)), wait)
+      );
+    }
+    console.error('Failed to send conversation', error);
   }
+}
+
+/**
+ * Computes a simple hash for the list of messages to prevent
+ * duplicate submissions.
+ * @param {string[]} messages
+ * @returns {string}
+ */
+function hashMessages(messages) {
+  return messages.join('|');
+}
+
+/**
+ * Handles DOM mutations by capturing the conversation and dispatching
+ * it to the backend when new messages appear.
+ */
+const handleUpdates = debounce(async () => {
+  const { platform, messages } = captureConversation();
+  if (!messages.length) return;
+
+  const hash = hashMessages(messages);
+  if (hash === state.lastHash) return;
+  state.lastHash = hash;
+
+  await sendToAPI({ platform, messages });
 });
 
-const observer = new MutationObserver(sendUpdates);
-observer.observe(document.body, { childList: true, subtree: true });
+/**
+ * Initializes a MutationObserver to watch the conversation container
+ * for changes. Retries if the container isn't yet in the DOM.
+ */
+function initObserver() {
+  const target = document.querySelector(CONFIG.SELECTORS.container);
+  if (!target) {
+    setTimeout(initObserver, 500);
+    return;
+  }
 
-sendUpdates();
+  const observer = new MutationObserver(handleUpdates);
+  observer.observe(target, { childList: true, subtree: true });
+
+  // Initial attempt to capture existing conversation
+  handleUpdates();
+}
+
+// Kick off the observer as soon as the script loads
+initObserver();
+


### PR DESCRIPTION
## Summary
- refactor Claude content script into a self-contained module with no imports
- capture Claude conversations and push them directly to the API with retry logic

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c50c979ae08324be3d3cdf3d0d5599