### PR TITLE
feat: improve claude content script message capture

### DIFF
--- a/extension/content/claude.js
+++ b/extension/content/claude.js
@@ -1,59 +1,106 @@
+import { debounce } from './utils.js';
+
 /**
- * Content script for capturing conversations on claude.ai and
- * sending them to the Master Mind AI backend. The script is
- * self-contained and avoids external module imports so it can run
- * as a plain content script in any Chromium-based browser.
+ * Content script for capturing conversations on claude.ai.
+ * Observes DOM mutations, extracts user/assistant messages and
+ * sends them to the Master Mind AI backend.
  */
 
-// Configuration for backend communication and DOM selectors
 const CONFIG = {
   API_URL: 'https://master-mind-ai.onrender.com/api/v1/conversations/',
-  SELECTORS: {
-    // Root container for the conversation
-    container: 'main',
-    // Individual message nodes within the conversation
-    message: 'main [data-message-id]'
-  },
-  RETRY: {
-    attempts: 3,
-    baseDelay: 1000 // milliseconds
+  RETRY: { attempts: 3, baseDelay: 1000 },
+  IGNORE_TEXT: ['Copy', 'Edit', 'Retry'],
+  DEDUPE_WINDOW: 10000 // milliseconds
+};
+
+// Buffer for pending messages and map for deduplication
+const buffer = [];
+const seen = new Map();
+
+/**
+ * Determine whether the element represents a user or assistant message
+ * by inspecting its class names and data attributes.
+ * @param {Element} el
+ * @returns {'user'|'assistant'|null}
+ */
+function detectRole(el) {
+  const id = `${el.className} ${Object.values(el.dataset).join(' ')}`.toLowerCase();
+  if (/user|human/.test(id)) return 'user';
+  if (/assistant|bot|ai|claude/.test(id)) return 'assistant';
+  return null;
+}
+
+/**
+ * Remove stale entries from the dedupe map so it doesn't grow endlessly.
+ */
+function pruneSeen() {
+  const cutoff = Date.now() - CONFIG.DEDUPE_WINDOW;
+  for (const [text, ts] of seen) {
+    if (ts < cutoff) seen.delete(text);
   }
-};
-
-// Tracks state for duplicate detection
-const state = {
-  lastHash: ''
-};
-
-/**
- * Simple debounce implementation to throttle rapid DOM updates.
- * @param {Function} fn - function to debounce
- * @param {number} wait - delay in milliseconds
- * @returns {Function}
- */
-function debounce(fn, wait = 1000) {
-  let t;
-  return (...args) => {
-    clearTimeout(t);
-    t = setTimeout(() => fn.apply(null, args), wait);
-  };
 }
 
 /**
- * Extracts all visible messages from the page.
- * @returns {{ platform: string, messages: string[] }}
+ * Extract messages from a newly added node and queue them for sending.
+ * @param {Node} node
  */
-function captureConversation() {
-  const nodes = document.querySelectorAll(CONFIG.SELECTORS.message);
-  const messages = Array.from(nodes, node => node.innerText.trim()).filter(Boolean);
-  return { platform: 'claude', messages };
+function collectMessages(node) {
+  if (node.nodeType !== Node.ELEMENT_NODE) return;
+  pruneSeen();
+
+  const elements = [node, ...node.querySelectorAll('*')];
+  for (const el of elements) {
+    const text = el.innerText?.trim();
+    if (!text || CONFIG.IGNORE_TEXT.includes(text)) continue;
+
+    const role = detectRole(el);
+    if (!role) continue;
+
+    const last = seen.get(text);
+    if (last && Date.now() - last < CONFIG.DEDUPE_WINDOW) continue;
+
+    seen.set(text, Date.now());
+    buffer.push({ role, content: text, timestamp: new Date().toISOString() });
+  }
 }
 
 /**
- * Sends conversation data to the backend with basic retry logic.
- * @param {Object} payload - data to send
- * @param {number} attempt - current retry attempt
- * @returns {Promise<void>}
+ * Debounced sender that posts buffered messages to the backend.
+ */
+const flush = debounce(async () => {
+  if (!buffer.length) return;
+  const payload = { platform: 'claude', messages: buffer.splice(0) };
+  await sendToAPI(payload);
+}, 500);
+
+/**
+ * Handle DOM mutations by processing newly added nodes. Also attaches
+ * observers to any encountered shadow roots.
+ * @param {MutationRecord[]} mutations
+ */
+function handleMutations(mutations) {
+  for (const m of mutations) {
+    m.addedNodes.forEach(node => {
+      collectMessages(node);
+      if (node.shadowRoot) observe(node.shadowRoot);
+    });
+  }
+  flush();
+}
+
+/**
+ * Observe a root node (document or shadow root) for future mutations.
+ * @param {Node} root
+ */
+function observe(root) {
+  const observer = new MutationObserver(handleMutations);
+  observer.observe(root, { childList: true, subtree: true });
+}
+
+/**
+ * Send a payload to the backend with retry and exponential backoff.
+ * @param {Object} payload
+ * @param {number} attempt
  */
 async function sendToAPI(payload, attempt = 0) {
   try {
@@ -62,67 +109,21 @@ async function sendToAPI(payload, attempt = 0) {
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(payload)
     });
-
-    if (!res.ok) {
-      throw new Error(`HTTP ${res.status}`);
-    }
-
-    // Consume response to avoid memory leaks
-    await res.json();
-  } catch (error) {
+    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+    await res.json().catch(() => {});
+  } catch (err) {
     if (attempt + 1 < CONFIG.RETRY.attempts) {
       const wait = CONFIG.RETRY.baseDelay * 2 ** attempt;
       return new Promise(resolve =>
         setTimeout(() => resolve(sendToAPI(payload, attempt + 1)), wait)
       );
     }
-    console.error('Failed to send conversation', error);
+    console.error('Failed to send conversation', err);
   }
 }
 
-/**
- * Computes a simple hash for the list of messages to prevent
- * duplicate submissions.
- * @param {string[]} messages
- * @returns {string}
- */
-function hashMessages(messages) {
-  return messages.join('|');
-}
-
-/**
- * Handles DOM mutations by capturing the conversation and dispatching
- * it to the backend when new messages appear.
- */
-const handleUpdates = debounce(async () => {
-  const { platform, messages } = captureConversation();
-  if (!messages.length) return;
-
-  const hash = hashMessages(messages);
-  if (hash === state.lastHash) return;
-  state.lastHash = hash;
-
-  await sendToAPI({ platform, messages });
-});
-
-/**
- * Initializes a MutationObserver to watch the conversation container
- * for changes. Retries if the container isn't yet in the DOM.
- */
-function initObserver() {
-  const target = document.querySelector(CONFIG.SELECTORS.container);
-  if (!target) {
-    setTimeout(initObserver, 500);
-    return;
-  }
-
-  const observer = new MutationObserver(handleUpdates);
-  observer.observe(target, { childList: true, subtree: true });
-
-  // Initial attempt to capture existing conversation
-  handleUpdates();
-}
-
-// Kick off the observer as soon as the script loads
-initObserver();
+// Begin observing the document and send any existing content
+observe(document.body);
+collectMessages(document.body);
+flush();
 


### PR DESCRIPTION
## Summary
- capture user and assistant messages on claude.ai using MutationObserver on document body and shadow roots
- batch and deduplicate messages with role detection and timestamps
- retry API posts with exponential backoff and error logging

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c52950eba88324922a45a502e2c82c