### PR TITLE
fix: inline debounce in Claude content script

### DIFF
--- a/extension/content/claude.js
+++ b/extension/content/claude.js
@@ -1,10 +1,16 @@
-import { debounce } from './utils.js';
-
 /**
  * Content script for capturing conversations on claude.ai.
  * Observes DOM mutations, extracts user/assistant messages and
  * sends them to the Master Mind AI backend.
  */
+
+function debounce(fn, wait = 500) {
+  let timeout;
+  return (...args) => {
+    clearTimeout(timeout);
+    timeout = setTimeout(() => fn.apply(null, args), wait);
+  };
+}
 
 const CONFIG = {
   API_URL: 'https://master-mind-ai.onrender.com/api/v1/conversations/',


### PR DESCRIPTION
## Summary
- inline debounce helper in Claude content script to avoid ES module import issues in Chrome extensions

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c52ba656808324900b0f57794870ad