### PR TITLE
refactor: replace claude content script with non-module version

### DIFF
--- a/extension/content/claude.js
+++ b/extension/content/claude.js
@@ -1,129 +1,168 @@
-import { debounce } from './utils.js';
-
 /**
  * Content script for capturing conversations on claude.ai.
- * Observes DOM mutations, extracts user/assistant messages and
- * sends them to the Master Mind AI backend.
+ * Chrome Extension compatible version - NO ES MODULES
  */
 
+function debounce(fn, wait = 500) {
+  let timeout;
+  return (...args) => {
+    clearTimeout(timeout);
+    timeout = setTimeout(() => fn.apply(null, args), wait);
+  };
+}
+
 const CONFIG = {
-  API_URL: 'https://master-mind-ai.onrender.com/api/v1/conversations/',
-  RETRY: { attempts: 3, baseDelay: 1000 },
   IGNORE_TEXT: ['Copy', 'Edit', 'Retry'],
-  DEDUPE_WINDOW: 10000 // milliseconds
+  DEDUPE_WINDOW: 10000
 };
 
-// Buffer for pending messages and map for deduplication
 const buffer = [];
 const seen = new Map();
 
-/**
- * Determine whether the element represents a user or assistant message
- * by inspecting its class names and data attributes.
- * @param {Element} el
- * @returns {'user'|'assistant'|null}
- */
 function detectRole(el) {
-  const id = `${el.className} ${Object.values(el.dataset).join(' ')}`.toLowerCase();
-  if (/user|human/.test(id)) return 'user';
-  if (/assistant|bot|ai|claude/.test(id)) return 'assistant';
-  return null;
+  try {
+    const id = `${el.className || ''} ${Object.values(el.dataset || {}).join(' ')}`.toLowerCase();
+    if (/user|human/.test(id)) return 'user';
+    if (/assistant|bot|ai|claude/.test(id)) return 'assistant';
+    return null;
+  } catch (error) {
+    console.warn('Error detecting role:', error);
+    return null;
+  }
 }
 
-/**
- * Remove stale entries from the dedupe map so it doesn't grow endlessly.
- */
 function pruneSeen() {
-  const cutoff = Date.now() - CONFIG.DEDUPE_WINDOW;
-  for (const [text, ts] of seen) {
-    if (ts < cutoff) seen.delete(text);
+  try {
+    const cutoff = Date.now() - CONFIG.DEDUPE_WINDOW;
+    for (const [text, ts] of seen) {
+      if (ts < cutoff) seen.delete(text);
+    }
+  } catch (error) {
+    console.warn('Error pruning seen messages:', error);
   }
 }
 
-/**
- * Extract messages from a newly added node and queue them for sending.
- * @param {Node} node
- */
 function collectMessages(node) {
-  if (node.nodeType !== Node.ELEMENT_NODE) return;
-  pruneSeen();
+  try {
+    if (!node || node.nodeType !== Node.ELEMENT_NODE) return;
+    pruneSeen();
 
-  const elements = [node, ...node.querySelectorAll('*')];
-  for (const el of elements) {
-    const text = el.innerText?.trim();
-    if (!text || CONFIG.IGNORE_TEXT.includes(text)) continue;
+    const elements = [node, ...node.querySelectorAll('*')];
+    for (const el of elements) {
+      const text = el.innerText?.trim();
+      if (!text || CONFIG.IGNORE_TEXT.includes(text)) continue;
 
-    const role = detectRole(el);
-    if (!role) continue;
+      const role = detectRole(el);
+      if (!role) continue;
 
-    const last = seen.get(text);
-    if (last && Date.now() - last < CONFIG.DEDUPE_WINDOW) continue;
+      const last = seen.get(text);
+      if (last && Date.now() - last < CONFIG.DEDUPE_WINDOW) continue;
 
-    seen.set(text, Date.now());
-    buffer.push({ role, content: text, timestamp: new Date().toISOString() });
+      seen.set(text, Date.now());
+      buffer.push({ 
+        role, 
+        content: text, 
+        timestamp: new Date().toISOString() 
+      });
+      
+      console.log('Captured message:', role, text.slice(0, 50) + '...');
+    }
+  } catch (error) {
+    console.error('Error collecting messages:', error);
   }
 }
 
-/**
- * Debounced sender that posts buffered messages to the backend.
- */
+async function sendToAPI(payload) {
+  try {
+    if (!chrome?.runtime?.sendMessage) {
+      console.error('Chrome runtime not available');
+      return;
+    }
+
+    console.log('Sending to background script:', payload);
+    
+    const response = await chrome.runtime.sendMessage({
+      type: 'conversation',
+      platform: payload.platform,
+      messages: payload.messages
+    });
+    
+    if (response?.success) {
+      console.log('Successfully sent conversation to Master Mind AI');
+    } else {
+      console.error('Background script error:', response?.error || 'Unknown error');
+    }
+  } catch (error) {
+    console.error('Message passing failed:', error);
+    if (error.message.includes('Extension context invalidated')) {
+      setTimeout(() => sendToAPI(payload), 1000);
+    }
+  }
+}
+
 const flush = debounce(async () => {
-  if (!buffer.length) return;
-  const payload = { platform: 'claude', messages: buffer.splice(0) };
-  await sendToAPI(payload);
+  try {
+    if (!buffer.length) return;
+    const payload = { 
+      platform: 'claude', 
+      messages: buffer.splice(0) 
+    };
+    await sendToAPI(payload);
+  } catch (error) {
+    console.error('Error in flush:', error);
+  }
 }, 500);
 
-/**
- * Handle DOM mutations by processing newly added nodes. Also attaches
- * observers to any encountered shadow roots.
- * @param {MutationRecord[]} mutations
- */
 function handleMutations(mutations) {
-  for (const m of mutations) {
-    m.addedNodes.forEach(node => {
-      collectMessages(node);
-      if (node.shadowRoot) observe(node.shadowRoot);
-    });
-  }
-  flush();
-}
-
-/**
- * Observe a root node (document or shadow root) for future mutations.
- * @param {Node} root
- */
-function observe(root) {
-  const observer = new MutationObserver(handleMutations);
-  observer.observe(root, { childList: true, subtree: true });
-}
-
-/**
- * Send a payload to the backend with retry and exponential backoff.
- * @param {Object} payload
- * @param {number} attempt
- */
-async function sendToAPI(payload, attempt = 0) {
   try {
-    const res = await fetch(CONFIG.API_URL, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(payload)
-    });
-    if (!res.ok) throw new Error(`HTTP ${res.status}`);
-    await res.json().catch(() => {});
-  } catch (err) {
-    if (attempt + 1 < CONFIG.RETRY.attempts) {
-      const wait = CONFIG.RETRY.baseDelay * 2 ** attempt;
-      return new Promise(resolve =>
-        setTimeout(() => resolve(sendToAPI(payload, attempt + 1)), wait)
-      );
+    for (const mutation of mutations) {
+      mutation.addedNodes.forEach(node => {
+        collectMessages(node);
+        if (node.shadowRoot) observe(node.shadowRoot);
+      });
     }
-    console.error('Failed to send conversation', err);
+    flush();
+  } catch (error) {
+    console.error('Error handling mutations:', error);
   }
 }
 
-// Begin observing the document and send any existing content
-observe(document.body);
-collectMessages(document.body);
-flush();
+function observe(root) {
+  try {
+    if (!root) return;
+    
+    const observer = new MutationObserver(handleMutations);
+    observer.observe(root, { 
+      childList: true, 
+      subtree: true 
+    });
+    
+    console.log('Observer attached to:', root.nodeName || 'shadow-root');
+  } catch (error) {
+    console.error('Error setting up observer:', error);
+  }
+}
+
+function initializeCapture() {
+  try {
+    console.log('Claude conversation capture initialized');
+    
+    if (document.readyState === 'loading') {
+      document.addEventListener('DOMContentLoaded', () => {
+        observe(document.body);
+        collectMessages(document.body);
+        flush();
+      });
+    } else {
+      observe(document.body);
+      collectMessages(document.body);
+      flush();
+    }
+  } catch (error) {
+    console.error('Error initializing capture:', error);
+  }
+}
+
+// Initialize with delay to ensure extension context is ready
+setTimeout(initializeCapture, 100);
 

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -28,8 +28,7 @@
     {
       "matches": ["https://claude.ai/*"],
       "js": ["content/claude.js"],
-      "run_at": "document_idle",
-      "type": "module"
+      "run_at": "document_idle"
     },
     {
       "matches": ["https://gemini.google.com/*"],


### PR DESCRIPTION
## Summary
- replace Claude content script with runtime messaging and non-module setup
- remove ES module flag for Claude content script in manifest

## Testing
- `npm test`
- `pytest` *(fails: SECRET_KEY not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c554d7d83083249ee32ba479471043