### PR TITLE
Add prompt enhancement endpoint and memory service support

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,13 @@ Browser Extension → Django API → Mem0 Memory Layer
 See [`docs/testing.md`](docs/testing.md) for running backend and extension tests.
 Deployment steps and security practices are described in [`docs/deployment.md`](docs/deployment.md).
 
+## API Endpoints
+
+- `GET /api/v1/health/` – Service health check
+- `POST /api/v1/conversations/` – Store a conversation
+- `POST /api/v1/conversations/search/` – Search stored memories
+- `POST /api/v1/prompts/enhance/` – Enhance a prompt with relevant memories
+
 ## Technology Stack
 - Django
 - PostgreSQL

--- a/backend/api/services/memory_service.py
+++ b/backend/api/services/memory_service.py
@@ -58,3 +58,25 @@ class MemoryService:
             filters=filters,
             vector_store=self.vector_store,
         )
+
+    def enhance_prompt(self, prompt: str, *, limit: int = 5) -> str:
+        """Enhance a prompt with relevant memories.
+
+        Memories retrieved from the vector store are prepended to the prompt,
+        separated by blank lines. If the service is disabled or no memories are
+        found, the original prompt is returned unchanged.
+        """
+        if not self.client:
+            return prompt
+
+        memories = self.search_memories(prompt, limit=limit)
+        context: List[str] = []
+        for memory in memories:
+            text = memory.get("content") or memory.get("memory") or ""
+            if text:
+                context.append(text)
+
+        if not context:
+            return prompt
+
+        return "\n".join(context) + "\n\n" + prompt

--- a/backend/api/urls.py
+++ b/backend/api/urls.py
@@ -8,10 +8,14 @@ from .views import (
     UserProfileViewSet,
     health_check,
 )
+from .views.enhancement import enhance_prompt
 
 router = DefaultRouter()
 router.register(r"users", UserProfileViewSet, basename="userprofile")
 router.register(r"projects", ProjectViewSet, basename="project")
 router.register(r"conversations", ConversationViewSet, basename="conversation")
 
-urlpatterns = [path("health/", health_check, name="health_check")] + router.urls
+urlpatterns = [
+    path("health/", health_check, name="health_check"),
+    path("prompts/enhance/", enhance_prompt, name="enhance_prompt"),
+] + router.urls

--- a/backend/api/views/__init__.py
+++ b/backend/api/views/__init__.py
@@ -11,9 +11,9 @@ from rest_framework import status, viewsets
 from rest_framework.decorators import action
 from rest_framework.response import Response
 
-from .models import Conversation, Project, UserProfile
-from .serializers import ConversationSerializer, ProjectSerializer, UserProfileSerializer
-from .services.memory_service import MemoryService
+from ..models import Conversation, Project, UserProfile
+from ..serializers import ConversationSerializer, ProjectSerializer, UserProfileSerializer
+from ..services.memory_service import MemoryService
 
 logger = logging.getLogger(__name__)
 

--- a/backend/api/views/enhancement.py
+++ b/backend/api/views/enhancement.py
@@ -1,0 +1,34 @@
+"""Endpoint for prompt enhancement using stored memories."""
+from __future__ import annotations
+
+import json
+import logging
+
+from django.http import JsonResponse
+from django.views.decorators.csrf import csrf_exempt
+from django.views.decorators.http import require_http_methods
+
+from ..services.memory_service import MemoryService
+
+logger = logging.getLogger(__name__)
+
+
+@csrf_exempt
+@require_http_methods(["POST"])
+def enhance_prompt(request):
+    """Enhance a user prompt with relevant memories."""
+    try:
+        data = json.loads(request.body or b"{}")
+    except json.JSONDecodeError:
+        return JsonResponse({"detail": "invalid JSON"}, status=400)
+
+    prompt = data.get("prompt")
+    if not prompt:
+        return JsonResponse({"detail": "prompt is required"}, status=400)
+
+    try:
+        enhanced = MemoryService().enhance_prompt(prompt)
+        return JsonResponse({"prompt": enhanced})
+    except Exception as exc:  # pragma: no cover - external dependency
+        logger.error("Prompt enhancement failed: %s", exc)
+        return JsonResponse({"detail": "enhancement failed"}, status=500)

--- a/backend/mastermind/settings.py
+++ b/backend/mastermind/settings.py
@@ -111,6 +111,7 @@ REST_FRAMEWORK = {
 }
 
 CORS_ALLOWED_ORIGINS = config("CORS_ALLOWED_ORIGINS", default="", cast=Csv())
+CORS_ALLOWED_ORIGIN_REGEXES = [r"^chrome-extension://.*$"]
 
 STATIC_URL = "static/"
 STATIC_ROOT = BASE_DIR / "staticfiles"

--- a/backend/tests/test_enhancement_endpoint.py
+++ b/backend/tests/test_enhancement_endpoint.py
@@ -1,0 +1,31 @@
+"""Tests for prompt enhancement endpoint."""
+from unittest.mock import patch
+
+from django.test import SimpleTestCase
+from rest_framework import status
+from rest_framework.test import APIRequestFactory
+import json
+
+from api.views.enhancement import enhance_prompt
+
+
+class EnhancementEndpointTests(SimpleTestCase):
+    """Validate enhancement API behavior."""
+
+    def setUp(self) -> None:
+        self.factory = APIRequestFactory()
+
+    def test_requires_prompt(self) -> None:
+        request = self.factory.post("/prompts/enhance/", {}, format="json")
+        response = enhance_prompt(request)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    @patch("api.views.enhancement.MemoryService.enhance_prompt", return_value="improved")
+    def test_returns_enhanced_prompt(self, mock_enhance) -> None:
+        request = self.factory.post(
+            "/prompts/enhance/", {"prompt": "hello"}, format="json"
+        )
+        response = enhance_prompt(request)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(json.loads(response.content), {"prompt": "improved"})
+        mock_enhance.assert_called_once_with("hello")


### PR DESCRIPTION
## Summary
- add `/api/v1/prompts/enhance/` endpoint for prompt enhancement
- extend `MemoryService` with `enhance_prompt` and wire URL routing
- allow chrome extensions via CORS and document API endpoints

## Testing
- `cd backend && pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c55740a2dc83249daef53873857515