### PR TITLE
docs: add repository file structure guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,9 @@ Browser Extension → Django API → Mem0 Memory Layer
    ```
 5. Load the browser extension in developer mode.
 
+## File Structure
+See [`docs/file-structure.md`](docs/file-structure.md) for an overview of repository files and directories.
+
 ## Testing & Deployment
 See [`docs/testing.md`](docs/testing.md) for running backend and extension tests.
 Deployment steps and security practices are described in [`docs/deployment.md`](docs/deployment.md).

--- a/docs/file-structure.md
+++ b/docs/file-structure.md
@@ -1,0 +1,48 @@
+# Project File Structure
+
+Overview of the repository with brief descriptions for major files and directories.
+
+```
+root
+├── AGENTS.md                 # Guidelines for contributors and agents
+├── CONTEXT.md                # Project background and architectural context
+├── Dockerfile                # Docker image definition for backend and extension
+├── README.md                 # Project overview and quick start guide
+├── docker-compose.yml        # Docker Compose setup for services
+├── env.example               # Example environment variables for local setup
+├── .env.render.example       # Example environment variables for Render deployment
+├── render.yaml               # Render service configuration
+├── render-build.sh           # Build script for Render deployments
+├── render-predeploy.sh       # Pre-deployment script for Render
+├── render-start.sh           # Startup script for Render
+├── backend/                  # Django REST API and server-side logic
+│   ├── manage.py             # Django management commands entry point
+│   ├── requirements.txt      # Python dependencies for backend
+│   ├── pytest.ini            # Pytest configuration
+│   ├── supabase_setup.sql    # SQL setup script for Supabase
+│   ├── api/                  # API app with views and serializers
+│   ├── mastermind/           # Django project configuration
+│   └── tests/                # Backend test suite
+├── extension/                # Chrome extension source
+│   ├── manifest.json         # Extension manifest (MV3)
+│   ├── background.js         # Background script handling events
+│   ├── content/              # Content scripts for capturing conversations
+│   ├── popup.html            # Popup UI markup
+│   ├── popup.js              # Logic for popup interactions
+│   ├── api.js                # Client for backend API requests
+│   ├── config.js             # Extension configuration values
+│   ├── styles.css            # Styling for popup
+│   ├── tests/                # Extension test suite
+│   ├── package.json          # Node dependencies and scripts
+│   └── package-lock.json     # Locked dependency versions
+├── docs/                     # Project documentation
+│   ├── deployment.md         # Deployment instructions
+│   ├── extension-setup.md    # Extension installation guide
+│   ├── render-deployment.md  # Render-specific deployment guide
+│   ├── testing.md            # Testing instructions
+│   └── file-structure.md     # (This file) repository layout guide
+└── deployment/               # Runtime scripts for deployments
+    ├── healthcheck.sh        # Health check script
+    └── start.sh              # Startup helper script
+```
+


### PR DESCRIPTION
## Summary
- document repository layout in new `docs/file-structure.md`
- link to file-structure guide from README

## Testing
- `cd backend && pytest` *(fails: SECRET_KEY not found)*
- `cd extension && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c55a86d4d4832498b9a1132df82b1c