### PR TITLE
feat: add floating enhance button with preview

### DIFF
--- a/extension/shared/enhancement-ui.js
+++ b/extension/shared/enhancement-ui.js
@@ -1,0 +1,115 @@
+function ensureSpinnerStyles() {
+  if (document.getElementById('mm-spinner-styles')) return;
+  const style = document.createElement('style');
+  style.id = 'mm-spinner-styles';
+  style.textContent = `@keyframes mm-spin{0%{transform:rotate(0deg)}100%{transform:rotate(360deg)}}`;
+  document.head.appendChild(style);
+}
+
+export default class EnhancementUI {
+  constructor() {
+    ensureSpinnerStyles();
+    this.container = document.createElement('div');
+    Object.assign(this.container.style, {
+      position: 'fixed',
+      top: '0',
+      left: '0',
+      width: '100%',
+      height: '100%',
+      display: 'none',
+      alignItems: 'center',
+      justifyContent: 'center',
+      background: 'rgba(0,0,0,0.4)',
+      zIndex: '2147483647',
+      fontFamily: 'sans-serif'
+    });
+    document.body.appendChild(this.container);
+  }
+
+  _buildBox() {
+    const box = document.createElement('div');
+    Object.assign(box.style, {
+      background: '#fff',
+      padding: '16px',
+      borderRadius: '8px',
+      maxWidth: '400px',
+      width: '90%',
+      boxSizing: 'border-box',
+      color: '#000'
+    });
+    return box;
+  }
+
+  showLoading() {
+    this.container.innerHTML = '';
+    const box = this._buildBox();
+    const spinner = document.createElement('div');
+    Object.assign(spinner.style, {
+      border: '4px solid #f3f3f3',
+      borderTop: '4px solid #555',
+      borderRadius: '50%',
+      width: '24px',
+      height: '24px',
+      animation: 'mm-spin 1s linear infinite',
+      margin: '0 auto 8px auto'
+    });
+    box.appendChild(spinner);
+    const text = document.createElement('div');
+    text.textContent = 'Enhancing...';
+    text.style.textAlign = 'center';
+    box.appendChild(text);
+    this.container.appendChild(box);
+    this.container.style.display = 'flex';
+  }
+
+  showPreview(enhanced) {
+    return new Promise(resolve => {
+      this.container.innerHTML = '';
+      const box = this._buildBox();
+      const preview = document.createElement('div');
+      preview.textContent = enhanced;
+      preview.style.whiteSpace = 'pre-wrap';
+      preview.style.marginBottom = '12px';
+      box.appendChild(preview);
+      const actions = document.createElement('div');
+      actions.style.textAlign = 'right';
+      const useBtn = document.createElement('button');
+      useBtn.textContent = 'Use';
+      useBtn.style.marginRight = '8px';
+      const cancelBtn = document.createElement('button');
+      cancelBtn.textContent = 'Cancel';
+      actions.appendChild(cancelBtn);
+      actions.appendChild(useBtn);
+      box.appendChild(actions);
+      cancelBtn.addEventListener('click', () => {
+        this.hide();
+        resolve(false);
+      });
+      useBtn.addEventListener('click', () => {
+        this.hide();
+        resolve(true);
+      });
+      this.container.appendChild(box);
+      this.container.style.display = 'flex';
+    });
+  }
+
+  showError(message) {
+    this.container.innerHTML = '';
+    const box = this._buildBox();
+    const text = document.createElement('div');
+    text.textContent = message;
+    text.style.marginBottom = '12px';
+    box.appendChild(text);
+    const close = document.createElement('button');
+    close.textContent = 'Close';
+    close.addEventListener('click', () => this.hide());
+    box.appendChild(close);
+    this.container.appendChild(box);
+    this.container.style.display = 'flex';
+  }
+
+  hide() {
+    this.container.style.display = 'none';
+  }
+}

--- a/extension/shared/floating-enhance-button.js
+++ b/extension/shared/floating-enhance-button.js
@@ -1,0 +1,48 @@
+export default class FloatingEnhanceButton {
+  constructor(onClick) {
+    this.onClick = onClick;
+    this.button = document.createElement('button');
+    this.button.textContent = 'Enhance';
+    Object.assign(this.button.style, {
+      position: 'absolute',
+      zIndex: '2147483647',
+      display: 'none',
+      padding: '4px 8px',
+      fontSize: '12px',
+      borderRadius: '4px',
+      border: 'none',
+      background: '#4b6fff',
+      color: '#fff',
+      cursor: 'pointer'
+    });
+    this.button.addEventListener('click', e => {
+      e.stopPropagation();
+      this.onClick?.();
+    });
+    document.body.appendChild(this.button);
+    this.target = null;
+
+    window.addEventListener('scroll', () => this.updatePosition(), true);
+    window.addEventListener('resize', () => this.updatePosition());
+  }
+
+  attach(el) {
+    this.target = el;
+    this.button.style.display = 'block';
+    this.updatePosition();
+  }
+
+  detach() {
+    this.button.style.display = 'none';
+    this.target = null;
+  }
+
+  updatePosition() {
+    if (!this.target || this.button.style.display === 'none') return;
+    const rect = this.target.getBoundingClientRect();
+    const top = window.scrollY + rect.bottom - this.button.offsetHeight - 8;
+    const left = window.scrollX + rect.right - this.button.offsetWidth - 8;
+    this.button.style.top = `${top}px`;
+    this.button.style.left = `${left}px`;
+  }
+}

--- a/extension/shared/text-replacement-manager.js
+++ b/extension/shared/text-replacement-manager.js
@@ -1,0 +1,23 @@
+export default class TextReplacementManager {
+  static getText(el) {
+    if (!el) return '';
+    if ('value' in el) return el.value;
+    if (el.isContentEditable) return el.textContent || '';
+    return '';
+  }
+
+  static setText(el, text) {
+    if (!el) return;
+    if ('value' in el) {
+      el.value = text;
+      el.dispatchEvent(new Event('input', { bubbles: true }));
+    } else if (el.isContentEditable) {
+      el.textContent = text;
+      el.dispatchEvent(new Event('input', { bubbles: true }));
+    }
+  }
+
+  static hasMinimumText(el, min = 10) {
+    return this.getText(el).trim().length >= min;
+  }
+}


### PR DESCRIPTION
## Summary
- add floating enhance button for active inputs
- provide enhancement UI with loading and confirmation
- replace ChatGPT shortcut with click flow using text manager

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c57f8625ec83248f4ac36b3b345f89