### PR TITLE
feat: enhance prompt with mem0 chat completions

### DIFF
--- a/backend/api/views/enhancement.py
+++ b/backend/api/views/enhancement.py
@@ -28,7 +28,7 @@ def enhance_prompt(request):
 
     try:
         enhanced = MemoryService().enhance_prompt(prompt)
-        return JsonResponse({"prompt": enhanced})
+        return JsonResponse({"enhanced_prompt": enhanced})
     except Exception as exc:  # pragma: no cover - external dependency
         logger.error("Prompt enhancement failed: %s", exc)
         return JsonResponse({"detail": "enhancement failed"}, status=500)

--- a/backend/tests/test_enhancement_endpoint.py
+++ b/backend/tests/test_enhancement_endpoint.py
@@ -27,5 +27,7 @@ class EnhancementEndpointTests(SimpleTestCase):
         )
         response = enhance_prompt(request)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(json.loads(response.content), {"prompt": "improved"})
+        self.assertEqual(
+            json.loads(response.content), {"enhanced_prompt": "improved"}
+        )
         mock_enhance.assert_called_once_with("hello")

--- a/backend/tests/test_memory_service.py
+++ b/backend/tests/test_memory_service.py
@@ -37,6 +37,7 @@ class MemoryServiceTests(TestCase):
     def test_enhance_prompt_includes_memories(self) -> None:
         with patch("api.services.memory_service.MemoryClient") as mock_client_cls:
             mock_client = MagicMock()
+            mock_client.chat.completions.create.side_effect = Exception("boom")
             mock_client_cls.return_value = mock_client
             service = MemoryService()
             with patch.object(
@@ -46,3 +47,4 @@ class MemoryServiceTests(TestCase):
                 self.assertIn("data", result)
                 self.assertTrue(result.endswith("hello"))
                 mock_search.assert_called_once_with("hello", limit=5)
+                mock_client.chat.completions.create.assert_called_once()

--- a/extension/content/chatgpt.js
+++ b/extension/content/chatgpt.js
@@ -50,11 +50,11 @@ function handleEnhance() {
   if (!prompt.trim()) return;
   ui.showLoading();
   chrome.runtime.sendMessage({ type: 'enhance', prompt }, res => {
-    if (chrome.runtime.lastError || !res?.success || !res.data?.enhanced_prompt) {
+    const enhanced = res?.data?.enhanced_prompt;
+    if (chrome.runtime.lastError || !res?.success || !enhanced) {
       ui.showError('Sorry, enhancement is unavailable. Please try again later.');
       return;
     }
-    const enhanced = res.data.enhanced_prompt;
     ui.showPreview(enhanced).then(use => {
       if (use) {
         TextReplacementManager.setText(el, enhanced);


### PR DESCRIPTION
## Summary
- switch enhancement endpoint to return `enhanced_prompt`
- use Mem0 chat completions with fallback to prepended memories
- align ChatGPT extension handler with new response format

## Testing
- `SECRET_KEY=foo POSTGRES_DB=foo POSTGRES_USER=foo POSTGRES_PASSWORD=foo POSTGRES_HOST=foo DEBUG=True pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c5a5c8b4348324b25f1fec3db7a741