### PR TITLE
fix: robust database config and logging

### DIFF
--- a/env.example
+++ b/env.example
@@ -7,6 +7,8 @@ SECRET_KEY=change-me  # Replace with a secure key
 ALLOWED_HOSTS=localhost,127.0.0.1  # Comma-separated list of allowed hosts
 
 # PostgreSQL Database
+# Optionally use a single DATABASE_URL instead of individual settings
+# DATABASE_URL=postgresql://user:password@localhost:5432/mastermind_db
 POSTGRES_DB=mastermind_db  # Database name
 POSTGRES_USER=mastermind_user  # Database user
 POSTGRES_PASSWORD=mastermind_pass  # Database password


### PR DESCRIPTION
## Summary
- parse database URLs correctly and add SSL and connection persistence
- improve logging output for easier debugging
- document optional DATABASE_URL env var

## Testing
- `pytest -q` *(fails: HealthEndpointTests::test_health_check_database_error, HealthEndpointTests::test_health_check_success)*

------
https://chatgpt.com/codex/tasks/task_e_68c5b13bd6948324a7fde13e58adb48e