### PR TITLE
Use django-environ for config and document Supabase settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,24 @@ Browser Extension → Django API → Mem0 Memory Layer
    ```
 5. Load the browser extension in developer mode.
 
+## Environment Variables
+
+Configuration uses a `.env` file. Copy the example file and supply your values:
+
+```bash
+cp env.example .env
+```
+
+Key settings include:
+
+- `DATABASE_URL` – PostgreSQL connection string (`postgresql://...`)
+- `SUPABASE_URL` and `SUPABASE_KEY` – Supabase project credentials
+- `SUPABASE_DB_URL` – Supabase PostgreSQL connection string
+- `SUPABASE_SERVICE_ROLE_KEY` – optional service role key for admin tasks
+- `MEM0_API_KEY` – Mem0.ai API key
+
+The `.env` file is git-ignored and must be created in each environment.
+
 ## File Structure
 See [`docs/file-structure.md`](docs/file-structure.md) for an overview of repository files and directories.
 

--- a/backend/api/services/memory_service.py
+++ b/backend/api/services/memory_service.py
@@ -19,8 +19,10 @@ class MemoryService:
 
         api_key = getattr(settings, "MEM0_API_KEY", "")
         db_url = getattr(settings, "SUPABASE_DB_URL", "")
+        supabase_url = getattr(settings, "SUPABASE_URL", "")
+        supabase_key = getattr(settings, "SUPABASE_KEY", "")
 
-        if not api_key or not db_url:
+        if not all([api_key, db_url, supabase_url, supabase_key]):
             logger.warning("Mem0 service disabled: missing configuration")
             self.client = None
             self.vector_store = None
@@ -31,6 +33,8 @@ class MemoryService:
             "provider": settings.MEM0_PROVIDER,
             "config": {
                 "connection_string": db_url,
+                "supabase_url": supabase_url,
+                "supabase_key": supabase_key,
                 "embedding_model_dims": settings.MEM0_EMBEDDING_DIM,
                 "index_method": settings.MEM0_INDEX_METHOD,
             },

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -3,7 +3,7 @@ djangorestframework==3.14.0
 psycopg2-binary==2.9.7
 pgvector==0.2.4
 django-cors-headers==4.3.1
-python-decouple==3.8
+django-environ==0.12.0
 requests==2.31.0
 mem0ai==0.1.117
 dj-database-url==3.0.1

--- a/backend/tests/test_memory_service.py
+++ b/backend/tests/test_memory_service.py
@@ -9,7 +9,16 @@ from api.services.memory_service import MemoryService
 class MemoryServiceTests(TestCase):
     """Validate MemoryService behavior."""
 
-    @override_settings(MEM0_API_KEY="key", SUPABASE_DB_URL="postgres://", MEM0_API_BASE_URL="https://mem0.example", MEM0_PROVIDER="supabase", MEM0_EMBEDDING_DIM=1536, MEM0_INDEX_METHOD="hnsw")
+    @override_settings(
+        MEM0_API_KEY="key",
+        SUPABASE_DB_URL="postgres://",
+        SUPABASE_URL="https://supabase.example",
+        SUPABASE_KEY="anon-key",
+        MEM0_API_BASE_URL="https://mem0.example",
+        MEM0_PROVIDER="supabase",
+        MEM0_EMBEDDING_DIM=1536,
+        MEM0_INDEX_METHOD="hnsw",
+    )
     def test_add_memory_uses_client(self) -> None:
         """add_memory should delegate to client with vector_store."""
         with patch("api.services.memory_service.MemoryClient") as mock_client_cls:
@@ -19,7 +28,12 @@ class MemoryServiceTests(TestCase):
             service.add_memory("hello", {"foo": "bar"})
             mock_client.add.assert_called_once()
 
-    @override_settings(MEM0_API_KEY="", SUPABASE_DB_URL="")
+    @override_settings(
+        MEM0_API_KEY="",
+        SUPABASE_DB_URL="",
+        SUPABASE_URL="",
+        SUPABASE_KEY="",
+    )
     def test_service_disabled_without_config(self) -> None:
         """Service should safely no-op when configuration missing."""
         service = MemoryService()
@@ -29,6 +43,8 @@ class MemoryServiceTests(TestCase):
     @override_settings(
         MEM0_API_KEY="key",
         SUPABASE_DB_URL="postgres://",
+        SUPABASE_URL="https://supabase.example",
+        SUPABASE_KEY="anon-key",
         MEM0_API_BASE_URL="https://mem0.example",
         MEM0_PROVIDER="supabase",
         MEM0_EMBEDDING_DIM=1536,

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,8 @@ services:
       - DJANGO_SETTINGS_MODULE=mastermind.settings
       - MEM0_API_KEY=${MEM0_API_KEY}
       - SUPABASE_DB_URL=${SUPABASE_DB_URL}
+      - SUPABASE_URL=${SUPABASE_URL}
+      - SUPABASE_KEY=${SUPABASE_KEY}
     depends_on:
       - db
   db:

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -5,8 +5,8 @@
 - Services: Django backend and PostgreSQL.
 
 ## Environment
-- Set `MEM0_API_KEY` and `SUPABASE_DB_URL` before running.
-- Use `.env` files or platform secrets, never commit keys.
+- Configure `MEM0_API_KEY`, `SUPABASE_DB_URL`, `SUPABASE_URL`, and `SUPABASE_KEY` before running.
+- Copy `env.example` to `.env` and populate values. The `.env` file is git-ignored; use platform secrets for production.
 
 ## Security Best Practices
 - Rotate secrets regularly.

--- a/env.example
+++ b/env.example
@@ -18,8 +18,8 @@ POSTGRES_PORT=5432  # Database port
 # Supabase configuration
 SUPABASE_DB_URL=postgresql://user:password@db.supabase.co:5432/postgres  # Supabase connection string
 SUPABASE_URL=https://your-project.supabase.co  # Supabase project URL
-SUPABASE_ANON_KEY=your-anon-key  # Supabase anon key
-SUPABASE_SERVICE_ROLE_KEY=your-service-role-key  # Supabase service role key
+SUPABASE_KEY=your-anon-key  # Supabase client key
+SUPABASE_SERVICE_ROLE_KEY=your-service-role-key  # Optional: service role key for admin tasks
 
 # Mem0.ai API
 MEM0_API_KEY=your-mem0-api-key  # API key for Mem0.ai


### PR DESCRIPTION
## Summary
- replace python-decouple with django-environ
- load Supabase URL and key in settings and services
- document `.env` setup and Supabase variables

## Testing
- `DEBUG=True SECRET_KEY=test SUPABASE_URL=https://supabase.example SUPABASE_KEY=anon-key pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c621cf33388324b4cc59106c72bdbe