### PR TITLE
Add user-specific prompt enhancement support

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Deployment steps and security practices are described in [`docs/deployment.md`](
 - `GET /api/v1/health/` – Service health check
 - `POST /api/v1/conversations/` – Store a conversation
 - `POST /api/v1/conversations/search/` – Search stored memories
-- `POST /api/v1/prompts/enhance/` – Enhance a prompt with relevant memories
+- `POST /api/v1/prompts/enhance/` – Enhance a prompt with relevant memories (accepts `prompt` and optional `user_id`)
 
 ## Technology Stack
 - Django


### PR DESCRIPTION
## Summary
- send `user_id: 'testuser'` with each prompt enhancement request from the extension
- accept and forward `user_id` in the backend enhance endpoint
- ensure MemoryService queries and chat completions use provided `user_id` or default to `testuser`
- document optional `user_id` parameter for the enhance endpoint

## Testing
- `npm test --prefix extension`
- `pytest` *(fails: SECRET_KEY not found / settings not configured)*

------
https://chatgpt.com/codex/tasks/task_e_68c6bbe3cae88324a9aeea3cd39ac2d6