### PR TITLE
fix: prevent duplicate enhance requests

### DIFF
--- a/extension/api.js
+++ b/extension/api.js
@@ -57,10 +57,14 @@ class APIClient {
   }
 
   async enhancePrompt(payload) {
-    const { userId } = await getSettings();
     const enhancedPayload = { prompt: payload.prompt };
-    if (userId) {
-      enhancedPayload.user_id = userId;
+    if (payload.user_id) {
+      enhancedPayload.user_id = payload.user_id;
+    } else {
+      const { userId } = await getSettings();
+      if (userId) {
+        enhancedPayload.user_id = userId;
+      }
     }
 
     return this.request('/api/v1/prompts/enhance/', {

--- a/extension/background.js
+++ b/extension/background.js
@@ -1,4 +1,5 @@
 import { apiClient } from './api.js';
+import { getSettings } from './config.js';
 
 let healthStatus = { ok: false };
 
@@ -61,16 +62,20 @@ chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
 
   if (msg.type === 'enhance') {
     console.log('🚀 Enhancing prompt:', msg.prompt?.slice(0, 50) + '...');
-    apiClient
-      .enhancePrompt({ prompt: msg.prompt })
-      .then(data => {
-        console.log('✅ Prompt enhanced successfully');
-        sendResponse({ success: true, data });
-      })
-      .catch(error => {
-        console.error('❌ Failed to enhance prompt:', error.message);
-        sendResponse({ success: false, error: error.message });
-      });
+    getSettings().then(({ userId }) => {
+      const payload = { prompt: msg.prompt };
+      if (userId) payload.user_id = userId;
+      apiClient
+        .enhancePrompt(payload)
+        .then(data => {
+          console.log('✅ Prompt enhanced successfully');
+          sendResponse({ success: true, data });
+        })
+        .catch(error => {
+          console.error('❌ Failed to enhance prompt:', error.message);
+          sendResponse({ success: false, error: error.message });
+        });
+    });
     return true;
   }
 

--- a/extension/content/chatgpt.js
+++ b/extension/content/chatgpt.js
@@ -26,24 +26,27 @@
     console.log('🔍 Platform config:', platform, selectors);
 
     function handleEnhance() {
-      console.log('🚀 Enhancement process started');
-      const el = button.target;
-      if (!el) return;
+      return new Promise(resolve => {
+        console.log('🚀 Enhancement process started');
+        const el = button.target;
+        if (!el) return resolve();
 
-      const prompt = TextReplacementManager.getText(el);
-      if (!prompt.trim()) return;
+        const prompt = TextReplacementManager.getText(el);
+        if (!prompt.trim()) return resolve();
 
-      ui.showLoading();
+        ui.showLoading();
 
-      chrome.runtime.sendMessage({ type: 'enhance', prompt }, res => {
-        ui.hide();
-        const enhanced = res?.data?.enhanced_prompt;
-        if (!enhanced) {
-          ui.showError('Enhancement failed. Please try again.');
-          return;
-        }
-        TextReplacementManager.setText(el, enhanced);
-        console.log('✅ Text replaced');
+        chrome.runtime.sendMessage({ type: 'enhance', prompt }, res => {
+          ui.hide();
+          const enhanced = res?.data?.enhanced_prompt;
+          if (!enhanced) {
+            ui.showError('Enhancement failed. Please try again.');
+            return resolve();
+          }
+          TextReplacementManager.setText(el, enhanced);
+          console.log('✅ Text replaced');
+          resolve();
+        });
       });
     }
 

--- a/extension/shared/floating-enhance-button.js
+++ b/extension/shared/floating-enhance-button.js
@@ -20,11 +20,10 @@ export default class FloatingEnhanceButton {
       boxShadow: '0 2px 4px rgba(0,0,0,0.2)'
     });
 
-    // Multiple event listeners to ensure click works
+    this.isProcessing = false;
+
     this.boundClick = this.handleClick.bind(this);
     this.button.addEventListener('click', this.boundClick, { capture: true });
-    this.button.addEventListener('mousedown', this.boundClick, { capture: true });
-    this.button.addEventListener('touchstart', this.boundClick, { capture: true });
 
     document.body.appendChild(this.button);
     this.target = null;
@@ -41,12 +40,14 @@ export default class FloatingEnhanceButton {
     console.log('🖱️ Button clicked!', e.type);
     e.stopPropagation();
     e.preventDefault();
-    
-    if (this.onClick) {
-      this.onClick();
-    } else {
-      console.error('❌ No onClick handler provided');
-    }
+
+    if (this.isProcessing) return;
+    this.isProcessing = true;
+
+    const result = this.onClick ? this.onClick() : null;
+    Promise.resolve(result).finally(() => {
+      this.isProcessing = false;
+    });
   }
 
   attach(el) {
@@ -77,8 +78,6 @@ export default class FloatingEnhanceButton {
     window.removeEventListener('scroll', this.boundScroll, true);
     window.removeEventListener('resize', this.boundResize);
     this.button.removeEventListener('click', this.boundClick, { capture: true });
-    this.button.removeEventListener('mousedown', this.boundClick, { capture: true });
-    this.button.removeEventListener('touchstart', this.boundClick, { capture: true });
     this.button.remove();
     this.target = null;
     console.log('🗑️ FloatingEnhanceButton destroyed');


### PR DESCRIPTION
## Summary
- prevent rapid re-triggering by tracking button processing state
- include user_id when enhancing prompts
- remove redundant event listeners and handle promise completion

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c80a80fc7483249c1d703026f165dc