### PR TITLE
feat: add Perplexity support to extension

### DIFF
--- a/extension/content/claude.js
+++ b/extension/content/claude.js
@@ -4,14 +4,18 @@
     
     const [
       { default: DOMObserver },
-      { getPlatformConfig }
+      { getPlatformConfig },
+      { UniversalEnhanceSystem }
     ] = await Promise.all([
       import(chrome.runtime.getURL('shared/dom-observer.js')),
-      import(chrome.runtime.getURL('shared/platform-config.js'))
+      import(chrome.runtime.getURL('shared/platform-config.js')),
+      import(chrome.runtime.getURL('shared/universal-enhance.js'))
     ]);
 
-    const { platform, selectors } = getPlatformConfig('claude');
+    const { platform, selectors, placement } = getPlatformConfig('claude');
     const observer = new DOMObserver(selectors);
+    const enhanceSystem = new UniversalEnhanceSystem(platform, selectors, placement);
+    await enhanceSystem.initialize();
 
     observer.subscribe('conversation-capture', () => {
       const nodes = document.querySelectorAll(selectors['conversation-capture']);
@@ -26,28 +30,7 @@
     });
 
     observer.subscribe('input-detection', elements => {
-      elements.forEach(el => {
-        if (el.dataset.mmEnhanceBound) return;
-        el.dataset.mmEnhanceBound = 'true';
-        
-        el.addEventListener('keydown', e => {
-          if ((e.metaKey || e.ctrlKey) && e.key === 'Enter') {
-            const prompt = el.value || el.textContent || '';
-            if (!prompt.trim()) return;
-            
-            chrome.runtime.sendMessage({ type: 'enhance', prompt }, res => {
-              if (res?.success && res.data?.enhanced_prompt) {
-                if ('value' in el) {
-                  el.value = res.data.enhanced_prompt;
-                } else {
-                  el.textContent = res.data.enhanced_prompt;
-                }
-              }
-            });
-            e.preventDefault();
-          }
-        });
-      });
+      enhanceSystem.attachDebounced(elements);
     });
 
     observer.start();

--- a/extension/content/perplexity.js
+++ b/extension/content/perplexity.js
@@ -1,6 +1,6 @@
 (async () => {
   try {
-    console.log('🚀 Loading Gemini content script...');
+    console.log('🚀 Loading Perplexity content script...');
     
     const [
       { default: DOMObserver },
@@ -12,7 +12,7 @@
       import(chrome.runtime.getURL('shared/universal-enhance.js'))
     ]);
 
-    const { platform, selectors, placement } = getPlatformConfig('gemini');
+    const { platform, selectors, placement } = getPlatformConfig('perplexity');
     const observer = new DOMObserver(selectors);
     const enhanceSystem = new UniversalEnhanceSystem(platform, selectors, placement);
     await enhanceSystem.initialize();
@@ -34,9 +34,9 @@
     });
 
     observer.start();
-    console.log('✅ Gemini content script loaded');
+    console.log('✅ Perplexity content script loaded');
 
   } catch (error) {
-    console.error('❌ Failed to load Gemini content script:', error);
+    console.error('❌ Failed to load Perplexity content script:', error);
   }
 })();

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -34,6 +34,11 @@
       "matches": ["https://gemini.google.com/*"],
       "js": ["content/gemini.js"],
       "run_at": "document_idle"
+    },
+    {
+      "matches": ["https://perplexity.ai/*"],
+      "js": ["content/perplexity.js"],
+      "run_at": "document_idle"
     }
   ],
   "web_accessible_resources": [{
@@ -41,14 +46,16 @@
       "https://chat.openai.com/*",
       "https://chatgpt.com/*",
       "https://claude.ai/*",
-      "https://gemini.google.com/*"
+      "https://gemini.google.com/*",
+      "https://perplexity.ai/*"
     ],
     "resources": [
       "shared/dom-observer.js",
-      "shared/platform-config.js", 
+      "shared/platform-config.js",
       "shared/floating-enhance-button.js",
       "shared/text-replacement-manager.js",
-      "shared/enhancement-ui.js"
+      "shared/enhancement-ui.js",
+      "shared/universal-enhance.js"
     ]
   }]
 }

--- a/extension/shared/floating-enhance-button.js
+++ b/extension/shared/floating-enhance-button.js
@@ -4,6 +4,7 @@ export default class FloatingEnhanceButton {
     this.button = document.createElement('button');
     this.button.textContent = 'Enhance';
     this.button.id = 'mm-enhance-btn'; // Add ID for debugging
+    this.element = this.button;
     
     Object.assign(this.button.style, {
       position: 'absolute',

--- a/extension/shared/platform-config.js
+++ b/extension/shared/platform-config.js
@@ -5,23 +5,39 @@ const PLATFORM_CONFIG = {
       'conversation-capture': 'main .markdown',
       'input-detection': 'div#prompt-textarea[contenteditable="true"], .ProseMirror[contenteditable="true"]',
       'message-updates': 'main .markdown'
-    }
+    },
+    placement: { strategy: 'inline', where: 'beforeend', inlineAlign: 'end' }
   },
+
   claude: {
     matches: [/claude\.ai/],
     selectors: {
       'conversation-capture': '[data-testid="conversation-message"]',
       'input-detection': 'textarea, [contenteditable="true"]',
       'message-updates': '[data-testid="conversation-message"]'
-    }
+    },
+    placement: { strategy: 'float', placement: 'right-start', gap: 8 }
   },
+
   gemini: {
     matches: [/gemini\.google\.com/],
     selectors: {
       'conversation-capture': '[data-message-id]',
       'input-detection': 'textarea',
       'message-updates': '[data-message-id]'
-    }
+    },
+    placement: { strategy: 'inline', where: 'beforeend', inlineAlign: 'end' }
+  },
+
+  perplexity: {
+    matches: [/perplexity\.ai/],
+    selectors: {
+      'conversation-capture': '[data-testid="conversation-turn"], .conversation-item',
+      'input-detection': 'textarea[placeholder*="Ask"], textarea[id="ask-input"], [contenteditable="true"]',
+      'message-updates': '[data-testid="conversation-turn"], .conversation-item',
+      'submit-button': 'button[aria-label="Submit"]'
+    },
+    placement: { strategy: 'inline', where: 'beforeend', inlineAlign: 'end' }
   }
 };
 
@@ -32,7 +48,14 @@ export function detectPlatform(url = window.location.href) {
 }
 
 export function getPlatformConfig(platform = detectPlatform()) {
-  return { platform, selectors: PLATFORM_CONFIG[platform]?.selectors || {} };
+  const config = PLATFORM_CONFIG[platform];
+  if (!config) return { platform, selectors: {}, placement: null };
+
+  return {
+    platform,
+    selectors: config.selectors || {},
+    placement: config.placement || null
+  };
 }
 
 export { PLATFORM_CONFIG };

--- a/extension/shared/universal-enhance.js
+++ b/extension/shared/universal-enhance.js
@@ -1,0 +1,144 @@
+/**
+ * Universal Enhancement System for Master Mind AI
+ * Enhanced with placement-aware positioning
+ */
+export class UniversalEnhanceSystem {
+  constructor(platform, selectors, placement = null) {
+    this.platform = platform;
+    this.selectors = selectors;
+    this.placement = placement;
+    this.button = null;
+    this.ui = null;
+    this.textManager = null;
+    this.initialized = false;
+    this.attachDebounced = this.debounce(this.attachToElements.bind(this), 100);
+  }
+
+  async initialize() {
+    if (this.initialized) {
+      return true;
+    }
+
+    const [
+      { default: FloatingEnhanceButton },
+      { default: TextReplacementManager },
+      { default: EnhancementUI }
+    ] = await Promise.all([
+      import(chrome.runtime.getURL('shared/floating-enhance-button.js')),
+      import(chrome.runtime.getURL('shared/text-replacement-manager.js')),
+      import(chrome.runtime.getURL('shared/enhancement-ui.js'))
+    ]);
+
+    this.ui = new EnhancementUI();
+    this.button = new FloatingEnhanceButton(() => this.handleEnhance());
+    this.textManager = TextReplacementManager;
+    this.initialized = true;
+
+    console.log(`\uD83D\uDD27 Universal enhance system initialized for ${this.platform}`);
+    return true;
+  }
+
+  handleEnhance() {
+    return new Promise(resolve => {
+      console.log('\uD83D\uDE80 Universal enhancement started');
+      const el = this.button?.target;
+      if (!el) {
+        return resolve();
+      }
+
+      const prompt = this.textManager?.getText(el) ?? '';
+      if (!prompt.trim()) {
+        return resolve();
+      }
+
+      this.ui?.showLoading();
+
+      chrome.runtime.sendMessage({ type: 'enhance', prompt }, res => {
+        this.ui?.hide();
+
+        if (chrome.runtime.lastError) {
+          console.error('Enhancement request failed', chrome.runtime.lastError);
+          this.ui?.showError('Enhancement failed. Please try again.');
+          return resolve();
+        }
+
+        const enhanced = res?.data?.enhanced_prompt;
+        if (!enhanced) {
+          this.ui?.showError('Enhancement failed. Please try again.');
+          return resolve();
+        }
+
+        this.textManager?.setText(el, enhanced);
+        console.log('\u2705 Universal enhancement completed');
+        resolve();
+      });
+    });
+  }
+
+  attachToElements(elements = []) {
+    if (!this.button || !Array.isArray(elements) || !elements.length) {
+      return;
+    }
+
+    const elementNodeType = typeof Node !== 'undefined' ? Node.ELEMENT_NODE : 1;
+    const validElements = elements.filter(
+      el => el && el.nodeType === elementNodeType
+    );
+
+    if (!validElements.length) {
+      return;
+    }
+
+    console.log(`\uD83D\uDCDD Attaching enhance button to ${validElements.length} elements on ${this.platform}`);
+    validElements.forEach(el => {
+      if (!el.dataset || el.dataset.mmEnhanceBound) {
+        return;
+      }
+
+      el.dataset.mmEnhanceBound = 'true';
+
+      if (this.placement) {
+        this.applyPlacement(el);
+      }
+
+      this.button.attach(el);
+      console.log(`\uD83C\uDFAF Button attached to ${this.platform} with placement:`, this.placement?.strategy || 'default');
+    });
+  }
+
+  applyPlacement(element) {
+    if (!this.placement || !this.button) return;
+
+    const buttonEl = this.button.element || this.button.button || null;
+    if (!buttonEl) return;
+
+    switch (this.placement.strategy) {
+      case 'float':
+        buttonEl.style.setProperty('position', 'absolute');
+        if (this.placement.gap) {
+          buttonEl.style.setProperty('margin', `${this.placement.gap}px`);
+        }
+        break;
+
+      case 'inline':
+        if (this.placement.inlineAlign === 'end') {
+          buttonEl.style.setProperty('margin-left', 'auto');
+        }
+        break;
+    }
+  }
+
+  debounce(func, wait) {
+    let timeout;
+    return function executedFunction(...args) {
+      const later = () => {
+        clearTimeout(timeout);
+        func(...args);
+      };
+      clearTimeout(timeout);
+      timeout = setTimeout(later, wait);
+    };
+  }
+}
+
+export default UniversalEnhanceSystem;

--- a/extension/tests/platform-config.test.js
+++ b/extension/tests/platform-config.test.js
@@ -5,10 +5,17 @@ describe('platform config', () => {
     expect(detectPlatform('https://chat.openai.com')).toBe('chatgpt');
     expect(detectPlatform('https://claude.ai/chat')).toBe('claude');
     expect(detectPlatform('https://gemini.google.com/app')).toBe('gemini');
+    expect(detectPlatform('https://perplexity.ai/search')).toBe('perplexity');
   });
 
   test('returns selectors for platform', () => {
-    const { selectors } = getPlatformConfig('gemini');
+    const { selectors, placement } = getPlatformConfig('gemini');
     expect(selectors['conversation-capture']).toBe('[data-message-id]');
+    expect(placement).toEqual({ strategy: 'inline', where: 'beforeend', inlineAlign: 'end' });
+  });
+
+  test('provides defaults for unknown platform', () => {
+    const config = getPlatformConfig('unknown');
+    expect(config).toEqual({ platform: 'unknown', selectors: {}, placement: null });
   });
 });


### PR DESCRIPTION
## Summary
- add Perplexity selectors, placement metadata, and defaults to the shared platform configuration
- introduce a universal enhancement system and hook Claude, Gemini, and the new Perplexity content scripts into it for consistent button placement and conversation capture
- expose the universal module through the manifest, add the Perplexity content script entry, and cover the new configuration behavior with tests

## Testing
- npm test -- --runTestsByPath tests/content-scripts.test.js *(fails: ENOENT for tests/content-scripts.test.js)*
- npm test


------
https://chatgpt.com/codex/tasks/task_e_68c94b813ff88324930341af4830cf10