### PR TITLE
Remove duplicate conversation capture in background handler

### DIFF
--- a/extension/background.js
+++ b/extension/background.js
@@ -42,8 +42,6 @@ chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
   }
 
   if (msg.type === 'conversation') {
-    handleConversationCapture(msg.platform, msg.messages);
-
     console.log('💾 Saving conversation:', msg.platform, msg.messages?.length, 'messages');
     apiClient
       .saveConversation({
@@ -97,53 +95,6 @@ chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
   return true;
 });
 
-async function handleConversationCapture(platform, messages) {
-  try {
-    if (!Array.isArray(messages) || !messages.length) {
-      return;
-    }
-
-    const storageData = await getStorageData([
-      'apiKey',
-      'accessToken',
-      'userId',
-      'memoryEnabled',
-      'apiToken'
-    ]);
-    const { apiKey, accessToken, userId, memoryEnabled, apiToken } = storageData;
-
-    if (!memoryEnabled) {
-      return;
-    }
-
-    const authToken = accessToken || apiKey || apiToken;
-    if (!authToken) {
-      return;
-    }
-
-    const authHeader = accessToken
-      ? `Bearer ${accessToken}`
-      : `Token ${apiKey || apiToken}`;
-
-    await fetch('https://api.mem0.ai/v1/memories/', {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        Authorization: authHeader
-      },
-      body: JSON.stringify({
-        messages: messages.map(msg => ({ role: 'user', content: msg })),
-        user_id: userId || 'chrome-extension-user',
-        infer: true,
-        metadata: { provider: platform },
-        source: 'OPENMEMORY_CHROME_EXTENSION'
-      })
-    }).catch(error => console.log('Memory storage failed:', error));
-  } catch (error) {
-    console.log('Conversation capture failed:', error);
-  }
-}
-
 async function handleEnhancement(prompt) {
   const payload = { prompt };
   const { userId } = await getSettings();
@@ -151,18 +102,6 @@ async function handleEnhancement(prompt) {
     payload.user_id = userId;
   }
   return apiClient.enhancePrompt(payload);
-}
-
-function getStorageData(keys) {
-  return new Promise((resolve, reject) => {
-    chrome.storage.sync.get(keys, data => {
-      if (chrome.runtime.lastError) {
-        reject(chrome.runtime.lastError);
-        return;
-      }
-      resolve(data);
-    });
-  });
 }
 
 console.log('🚀 Master Mind AI background script loaded');


### PR DESCRIPTION
## Summary
- remove the direct conversation capture call from the background handler so messages flow solely through `apiClient.saveConversation`

## Testing
- npm test -- --runTestsByPath tests/dom-observer.test.js
- npm test -- --runTestsByPath tests/platform-config.test.js tests/utils.test.js

------
https://chatgpt.com/codex/tasks/task_e_68c982d05ed083248634c6436ebc6062