### PR TITLE
Update popup project selection and remove API token

### DIFF
--- a/extension/api.js
+++ b/extension/api.js
@@ -1,14 +1,10 @@
 import { getSettings } from './config.js';
 
 class APIClient {
-  async request(path, { method = 'GET', body } = {}) {
-    const { apiBaseUrl, apiToken } = await getSettings();
-    const url = `${apiBaseUrl}${path}`;
+  async request(path, { method = 'GET', body, baseUrl } = {}) {
+    const { apiBaseUrl } = await getSettings();
+    const url = `${baseUrl ?? apiBaseUrl}${path}`;
     const headers = { 'Content-Type': 'application/json' };
-
-    if (apiToken) {
-      headers['Authorization'] = `Bearer ${apiToken}`;
-    }
 
     for (let attempt = 0; attempt < 3; attempt++) {
       try {
@@ -47,6 +43,10 @@ class APIClient {
 
   healthCheck() {
     return this.request('/api/v1/health/');
+  }
+
+  fetchProjects(baseUrl) {
+    return this.request('/api/v1/projects/', { baseUrl });
   }
 
   saveConversation(payload) {

--- a/extension/api.js
+++ b/extension/api.js
@@ -56,20 +56,10 @@ class APIClient {
     });
   }
 
-  async enhancePrompt(payload) {
-    const enhancedPayload = { prompt: payload.prompt };
-    if (payload.user_id) {
-      enhancedPayload.user_id = payload.user_id;
-    } else {
-      const { userId } = await getSettings();
-      if (userId) {
-        enhancedPayload.user_id = userId;
-      }
-    }
-
+  enhancePrompt(payload) {
     return this.request('/api/v1/prompts/enhance/', {
       method: 'POST',
-      body: JSON.stringify(enhancedPayload)
+      body: JSON.stringify(payload)
     });
   }
 

--- a/extension/background.js
+++ b/extension/background.js
@@ -62,7 +62,7 @@ chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
 
   if (msg.type === 'enhance') {
     console.log('🚀 Enhancing prompt:', msg.prompt?.slice(0, 50) + '...');
-    handleEnhancement(msg.prompt, msg.session_id, msg.run_id)
+    handleEnhancement(msg.prompt, msg.app_id, msg.run_id)
       .then(data => {
         console.log('✅ Prompt enhanced successfully');
         sendResponse({ success: true, data });
@@ -95,7 +95,7 @@ chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
   return true;
 });
 
-async function handleEnhancement(prompt, sessionId, runId) {
+async function handleEnhancement(prompt, appId, runId) {
   const payload = { prompt };
   const { userId, projectId } = await getSettings();
 
@@ -103,9 +103,9 @@ async function handleEnhancement(prompt, sessionId, runId) {
     payload.user_id = userId;
   }
 
-  const effectiveSession = sessionId || projectId;
-  if (effectiveSession) {
-    payload.session_id = effectiveSession;
+  const effectiveApp = appId || projectId;
+  if (effectiveApp) {
+    payload.app_id = effectiveApp;
   }
 
   if (runId) {

--- a/extension/background.js
+++ b/extension/background.js
@@ -62,7 +62,7 @@ chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
 
   if (msg.type === 'enhance') {
     console.log('🚀 Enhancing prompt:', msg.prompt?.slice(0, 50) + '...');
-    handleEnhancement(msg.prompt)
+    handleEnhancement(msg.prompt, msg.session_id, msg.run_id)
       .then(data => {
         console.log('✅ Prompt enhanced successfully');
         sendResponse({ success: true, data });
@@ -95,12 +95,23 @@ chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
   return true;
 });
 
-async function handleEnhancement(prompt) {
+async function handleEnhancement(prompt, sessionId, runId) {
   const payload = { prompt };
-  const { userId } = await getSettings();
+  const { userId, projectId } = await getSettings();
+
   if (userId) {
     payload.user_id = userId;
   }
+
+  const effectiveSession = sessionId || projectId;
+  if (effectiveSession) {
+    payload.session_id = effectiveSession;
+  }
+
+  if (runId) {
+    payload.run_id = runId;
+  }
+
   return apiClient.enhancePrompt(payload);
 }
 

--- a/extension/config.js
+++ b/extension/config.js
@@ -6,21 +6,21 @@ export const ENVIRONMENTS = {
 export function getSettings() {
   return new Promise(resolve => {
     chrome.storage.sync.get(
-      { environment: 'production', apiToken: '', userId: '' },
-      ({ environment, apiToken, userId }) => {
+      { environment: 'production', userId: '', projectId: '' },
+      ({ environment, userId, projectId }) => {
         resolve({
           apiBaseUrl: ENVIRONMENTS[environment] || ENVIRONMENTS.production,
-          apiToken,
           environment,
-          userId
+          userId,
+          projectId
         });
       }
     );
   });
 }
 
-export function setSettings({ environment, apiToken, userId }) {
+export function setSettings({ environment, userId, projectId }) {
   return new Promise(resolve => {
-    chrome.storage.sync.set({ environment, apiToken, userId }, resolve);
+    chrome.storage.sync.set({ environment, userId, projectId }, resolve);
   });
 }

--- a/extension/content/chatgpt.js
+++ b/extension/content/chatgpt.js
@@ -7,13 +7,17 @@
       { getPlatformConfig },
       { default: FloatingEnhanceButton },
       { default: TextReplacementManager },
-      { default: EnhancementUI }
+      { default: EnhancementUI },
+      { getRunId },
+      { getSettings }
     ] = await Promise.all([
       import(chrome.runtime.getURL('shared/dom-observer.js')),
       import(chrome.runtime.getURL('shared/platform-config.js')),
       import(chrome.runtime.getURL('shared/floating-enhance-button.js')),
       import(chrome.runtime.getURL('shared/text-replacement-manager.js')),
-      import(chrome.runtime.getURL('shared/enhancement-ui.js'))
+      import(chrome.runtime.getURL('shared/enhancement-ui.js')),
+      import(chrome.runtime.getURL('shared/thread-context.js')),
+      import(chrome.runtime.getURL('config.js'))
     ]);
 
     console.log('✅ All modules loaded successfully');
@@ -25,18 +29,34 @@
 
     console.log('🔍 Platform config:', platform, selectors);
 
-    function handleEnhance() {
+    async function handleEnhance() {
+      console.log('🚀 Enhancement process started');
+      const el = button.target;
+      if (!el) return;
+
+      const prompt = TextReplacementManager.getText(el);
+      if (!prompt.trim()) return;
+
+      ui.showLoading();
+
+      const message = { type: 'enhance', prompt };
+
+      try {
+        const { projectId } = await getSettings();
+        if (projectId) {
+          message.session_id = projectId;
+        }
+      } catch (error) {
+        console.warn('Failed to load project settings for ChatGPT enhancement', error);
+      }
+
+      const runId = getRunId();
+      if (runId) {
+        message.run_id = runId;
+      }
+
       return new Promise(resolve => {
-        console.log('🚀 Enhancement process started');
-        const el = button.target;
-        if (!el) return resolve();
-
-        const prompt = TextReplacementManager.getText(el);
-        if (!prompt.trim()) return resolve();
-
-        ui.showLoading();
-
-        chrome.runtime.sendMessage({ type: 'enhance', prompt }, res => {
+        chrome.runtime.sendMessage(message, res => {
           ui.hide();
           const enhanced = res?.data?.enhanced_prompt;
           if (!enhanced) {

--- a/extension/content/chatgpt.js
+++ b/extension/content/chatgpt.js
@@ -44,7 +44,7 @@
       try {
         const { projectId } = await getSettings();
         if (projectId) {
-          message.session_id = projectId;
+          message.app_id = projectId;
         }
       } catch (error) {
         console.warn('Failed to load project settings for ChatGPT enhancement', error);

--- a/extension/popup.html
+++ b/extension/popup.html
@@ -13,9 +13,12 @@
       <option value="development">Development</option>
     </select>
   </label>
-  <label>API Token
-    <input id="token" type="text" placeholder="token" />
-  </label>
+  <div class="form-group">
+    <label for="project-select">Project:</label>
+    <select id="project-select" required>
+      <option value="">Select project...</option>
+    </select>
+  </div>
   <label>User ID
     <input id="userId" type="text" placeholder="user" />
   </label>

--- a/extension/popup.js
+++ b/extension/popup.js
@@ -1,10 +1,80 @@
-import { getSettings, setSettings } from './config.js';
+import { ENVIRONMENTS, getSettings, setSettings } from './config.js';
+import { apiClient } from './api.js';
 
 const envEl = document.getElementById('environment');
-const tokenEl = document.getElementById('token');
+const projectEl = document.getElementById('project-select');
 const userIdEl = document.getElementById('userId');
 const statusEl = document.getElementById('status');
 const connectionEl = document.getElementById('connection');
+const saveButton = document.getElementById('save');
+
+let statusTimeoutId;
+
+function showStatus(message, isError = false) {
+  statusEl.textContent = message;
+  statusEl.style.color = isError ? 'red' : 'green';
+
+  if (statusTimeoutId) {
+    clearTimeout(statusTimeoutId);
+    statusTimeoutId = null;
+  }
+
+  if (message && !isError) {
+    statusTimeoutId = setTimeout(() => {
+      statusEl.textContent = '';
+      statusTimeoutId = null;
+    }, 2000);
+  }
+}
+
+function updateSaveButtonState() {
+  saveButton.disabled = projectEl.disabled || !projectEl.value;
+}
+
+async function loadProjects(selectedProjectId = '') {
+  const environment = envEl.value;
+  const baseUrl = ENVIRONMENTS[environment] || ENVIRONMENTS.production;
+
+  projectEl.disabled = true;
+  projectEl.innerHTML = '<option value="">Loading projects...</option>';
+  updateSaveButtonState();
+
+  try {
+    const response = await apiClient.fetchProjects(baseUrl);
+    const projects = Array.isArray(response) ? response : response?.results || [];
+
+    projectEl.innerHTML = '<option value="">Select project...</option>';
+
+    projects.forEach(project => {
+      const option = document.createElement('option');
+      option.value = String(project.id);
+      option.textContent = project.name;
+      projectEl.appendChild(option);
+    });
+
+    if (selectedProjectId) {
+      const matched = projects.find(project => String(project.id) === String(selectedProjectId));
+      if (matched) {
+        projectEl.value = String(matched.id);
+      } else {
+        projectEl.value = '';
+        showStatus('Saved project is unavailable. Please choose another project.', true);
+      }
+    }
+
+    if (!projects.length) {
+      showStatus('No projects available.', true);
+    }
+  } catch (error) {
+    console.error('Failed to load projects', error);
+    projectEl.innerHTML = '<option value="">Select project...</option>';
+    projectEl.value = '';
+    showStatus('Failed to load projects', true);
+  } finally {
+    projectEl.disabled = false;
+    updateSaveButtonState();
+  }
+}
 
 async function updateConnection() {
   connectionEl.textContent = 'Checking...';
@@ -16,19 +86,40 @@ async function updateConnection() {
 }
 
 async function init() {
-  const { environment, apiToken, userId } = await getSettings();
+  const { environment, userId, projectId } = await getSettings();
   envEl.value = environment;
-  tokenEl.value = apiToken;
   userIdEl.value = userId;
+  await loadProjects(projectId);
   updateConnection();
+  updateSaveButtonState();
 }
 
 init();
 
-document.getElementById('save').addEventListener('click', () => {
-  setSettings({ environment: envEl.value, apiToken: tokenEl.value, userId: userIdEl.value }).then(() => {
-    statusEl.textContent = 'Saved';
-    setTimeout(() => (statusEl.textContent = ''), 2000);
-    updateConnection();
-  });
+envEl.addEventListener('change', () => {
+  loadProjects(projectEl.value);
+});
+
+projectEl.addEventListener('change', () => {
+  if (statusEl.style.color === 'red' && statusEl.textContent) {
+    showStatus('');
+  }
+  updateSaveButtonState();
+});
+
+saveButton.addEventListener('click', () => {
+  if (!projectEl.value) {
+    updateSaveButtonState();
+    return;
+  }
+
+  setSettings({ environment: envEl.value, userId: userIdEl.value, projectId: projectEl.value })
+    .then(() => {
+      showStatus('Saved');
+      updateConnection();
+    })
+    .catch(error => {
+      console.error('Failed to save settings', error);
+      showStatus('Failed to save settings', true);
+    });
 });

--- a/extension/shared/dom-observer.js
+++ b/extension/shared/dom-observer.js
@@ -1,6 +1,8 @@
 // Centralized DOM Mutation Observer with subscriber support
 // Observes DOM changes and notifies registered callbacks for specific event types.
 
+import { clearRunId as clearGlobalRunId, setRunId as setGlobalRunId } from './thread-context.js';
+
 export class DOMObserver {
   constructor(selectors = {}) {
     this.selectors = selectors; // { eventType: cssSelector }
@@ -75,7 +77,7 @@ export class DOMObserver {
     this.callbacks = {};
     this.debouncers = {};
     this._detachInputListeners();
-    this.currentRunId = null;
+    this.clearCurrentRunId();
     this.conversationContainer = null;
     this.conversationHasMessages = false;
   }
@@ -215,19 +217,24 @@ export class DOMObserver {
     return this.currentRunId;
   }
 
-  setCurrentRunId(runId) {
-    this.currentRunId = runId;
-    return this.currentRunId;
-  }
-
   clearCurrentRunId() {
+    if (this.currentRunId === null) {
+      return;
+    }
     this.currentRunId = null;
+    clearGlobalRunId();
   }
 
   generateNewRunId() {
     const newRunId = `thread_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
     this.setCurrentRunId(newRunId);
     return newRunId;
+  }
+
+  setCurrentRunId(runId) {
+    this.currentRunId = runId;
+    setGlobalRunId(runId);
+    return this.currentRunId;
   }
 }
 

--- a/extension/shared/dom-observer.js
+++ b/extension/shared/dom-observer.js
@@ -7,6 +7,10 @@ export class DOMObserver {
     this.callbacks = {}; // { eventType: [fn, ...] }
     this.observer = null;
     this.debouncers = {}; // { eventType: debouncedFn }
+    this.inputHandlers = new Map(); // Map<Element, handler>
+    this.currentRunId = null;
+    this.conversationContainer = null;
+    this.conversationHasMessages = false;
   }
 
   subscribe(type, callback) {
@@ -40,7 +44,21 @@ export class DOMObserver {
     const selector = this.selectors[type];
     if (!selector) return;
     const elements = Array.from(document.querySelectorAll(selector));
-    if (!elements.length) return;
+    if (!elements.length) {
+      if (type === 'conversation-capture') {
+        this._handleConversationCleared();
+      }
+      return;
+    }
+
+    if (type === 'conversation-capture') {
+      this._rememberConversationContainer(elements);
+      this.conversationHasMessages = true;
+    }
+
+    if (type === 'input-detection') {
+      this._attachInputListeners(elements);
+    }
     const subs = this.callbacks[type] || [];
     subs.forEach(cb => cb(elements));
   }
@@ -56,6 +74,10 @@ export class DOMObserver {
     this.stop();
     this.callbacks = {};
     this.debouncers = {};
+    this._detachInputListeners();
+    this.currentRunId = null;
+    this.conversationContainer = null;
+    this.conversationHasMessages = false;
   }
 
   _debounce(fn, wait) {
@@ -64,6 +86,148 @@ export class DOMObserver {
       clearTimeout(t);
       t = setTimeout(() => fn.apply(this, args), wait);
     };
+  }
+
+  _attachInputListeners(elements = []) {
+    elements.forEach(el => {
+      if (!el || this.inputHandlers.has(el) || typeof el.addEventListener !== 'function') {
+        return;
+      }
+
+      const handler = () => this._onUserInput();
+      el.addEventListener('input', handler);
+      this.inputHandlers.set(el, handler);
+    });
+  }
+
+  _detachInputListeners() {
+    this.inputHandlers.forEach((handler, el) => {
+      if (el && typeof el.removeEventListener === 'function') {
+        el.removeEventListener('input', handler);
+      }
+    });
+    this.inputHandlers.clear();
+  }
+
+  _onUserInput() {
+    this._checkThreadState();
+  }
+
+  _checkThreadState() {
+    if (this._isConversationEmpty()) {
+      if (!this.getCurrentRunId()) {
+        this.generateNewRunId();
+      }
+    }
+  }
+
+  _isConversationEmpty() {
+    const container = this._getConversationContainer();
+    const captureSelector = this.selectors['conversation-capture'];
+
+    if (container) {
+      const relevantChildren = captureSelector
+        ? Array.from(container.querySelectorAll(captureSelector))
+        : Array.from(container.children);
+      const meaningfulNodes = relevantChildren.filter(node => this._nodeHasMeaningfulContent(node));
+      if (meaningfulNodes.length === 0) {
+        return true;
+      }
+      return false;
+    }
+
+    if (!captureSelector) {
+      return false;
+    }
+
+    const messageNodes = Array.from(document.querySelectorAll(captureSelector)).filter(node =>
+      this._nodeHasMeaningfulContent(node)
+    );
+    return messageNodes.length === 0;
+  }
+
+  _getConversationContainer() {
+    const containerSelector = this.selectors['conversation-container'];
+    if (containerSelector) {
+      const container = document.querySelector(containerSelector);
+      if (container) {
+        this.conversationContainer = container;
+        return container;
+      }
+    }
+
+    if (this.conversationContainer && this.conversationContainer.isConnected) {
+      return this.conversationContainer;
+    }
+
+    const captureSelector = this.selectors['conversation-capture'];
+    if (!captureSelector) {
+      return this.conversationContainer;
+    }
+
+    const firstMessage = document.querySelector(captureSelector);
+    if (firstMessage) {
+      const container = firstMessage.parentElement;
+      if (container) {
+        this.conversationContainer = container;
+        return container;
+      }
+    }
+
+    return this.conversationContainer;
+  }
+
+  _rememberConversationContainer(elements = []) {
+    if (this.conversationContainer && this.conversationContainer.isConnected) {
+      return;
+    }
+
+    if (!Array.isArray(elements) || !elements.length) {
+      return;
+    }
+
+    const directParent = elements[0]?.parentElement;
+    if (directParent) {
+      this.conversationContainer = directParent;
+      return;
+    }
+
+    this._getConversationContainer();
+  }
+
+  _nodeHasMeaningfulContent(node) {
+    if (!node) return false;
+    if (typeof node.innerText === 'string' && node.innerText.trim()) return true;
+    if (typeof node.textContent === 'string' && node.textContent.trim()) return true;
+    return false;
+  }
+
+  _handleConversationCleared() {
+    if (!this.conversationHasMessages) {
+      return;
+    }
+
+    this.conversationHasMessages = false;
+    this.clearCurrentRunId();
+  }
+
+  getCurrentRunId() {
+    return this.currentRunId;
+  }
+
+  setCurrentRunId(runId) {
+    this.currentRunId = runId;
+    return this.currentRunId;
+  }
+
+  clearCurrentRunId() {
+    this.currentRunId = null;
+  }
+
+  generateNewRunId() {
+    const newRunId = `thread_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
+    this.setCurrentRunId(newRunId);
+    return newRunId;
   }
 }
 

--- a/extension/shared/thread-context.js
+++ b/extension/shared/thread-context.js
@@ -1,0 +1,42 @@
+let currentRunId = null;
+const listeners = new Set();
+
+function notifyListeners() {
+  listeners.forEach(listener => {
+    try {
+      listener(currentRunId);
+    } catch (error) {
+      console.warn('Thread context listener failed', error);
+    }
+  });
+}
+
+export function getRunId() {
+  return currentRunId;
+}
+
+export function setRunId(runId) {
+  currentRunId = runId;
+  notifyListeners();
+  return currentRunId;
+}
+
+export function clearRunId() {
+  if (currentRunId === null) {
+    return;
+  }
+  currentRunId = null;
+  notifyListeners();
+}
+
+export function onRunIdChange(listener) {
+  if (typeof listener !== 'function') {
+    return () => {};
+  }
+
+  listeners.add(listener);
+
+  return () => {
+    listeners.delete(listener);
+  };
+}

--- a/extension/shared/universal-enhance.js
+++ b/extension/shared/universal-enhance.js
@@ -1,6 +1,9 @@
 /**
  * Universal Enhancement System for Master Mind AI
  */
+import { getSettings } from '../config.js';
+import { getRunId } from './thread-context.js';
+
 export class UniversalEnhanceSystem {
   constructor(platform, selectors, placement = null) {
     this.platform = platform;
@@ -37,22 +40,39 @@ export class UniversalEnhanceSystem {
     return true;
   }
 
-  handleEnhance() {
+  async handleEnhance() {
+    console.log('🚀 Universal enhancement started');
+    const el = this.button?.target;
+    if (!el) {
+      return;
+    }
+
+    const prompt = this.textManager?.getText(el) ?? '';
+    if (!prompt.trim()) {
+      return;
+    }
+
+    this.ui?.showLoading();
+
+    let sessionId = '';
+    try {
+      const { projectId } = await getSettings();
+      sessionId = projectId || '';
+    } catch (error) {
+      console.warn('Unable to load project settings for enhancement', error);
+    }
+
+    const runId = getRunId();
+    const message = { type: 'enhance', prompt };
+    if (sessionId) {
+      message.session_id = sessionId;
+    }
+    if (runId) {
+      message.run_id = runId;
+    }
+
     return new Promise(resolve => {
-      console.log('🚀 Universal enhancement started');
-      const el = this.button?.target;
-      if (!el) {
-        return resolve();
-      }
-
-      const prompt = this.textManager?.getText(el) ?? '';
-      if (!prompt.trim()) {
-        return resolve();
-      }
-
-      this.ui?.showLoading();
-
-      chrome.runtime.sendMessage({ type: 'enhance', prompt }, res => {
+      chrome.runtime.sendMessage(message, res => {
         this.ui?.hide();
 
         if (chrome.runtime.lastError) {

--- a/extension/shared/universal-enhance.js
+++ b/extension/shared/universal-enhance.js
@@ -54,18 +54,18 @@ export class UniversalEnhanceSystem {
 
     this.ui?.showLoading();
 
-    let sessionId = '';
+    let appId = '';
     try {
       const { projectId } = await getSettings();
-      sessionId = projectId || '';
+      appId = projectId || '';
     } catch (error) {
       console.warn('Unable to load project settings for enhancement', error);
     }
 
     const runId = getRunId();
     const message = { type: 'enhance', prompt };
-    if (sessionId) {
-      message.session_id = sessionId;
+    if (appId) {
+      message.app_id = appId;
     }
     if (runId) {
       message.run_id = runId;

--- a/extension/styles.css
+++ b/extension/styles.css
@@ -11,6 +11,20 @@ input {
   width: 100%;
   box-sizing: border-box;
 }
+
+select {
+  width: 100%;
+  box-sizing: border-box;
+}
+
+.form-group {
+  margin-bottom: 8px;
+}
+
+.form-group label {
+  display: block;
+  margin-bottom: 4px;
+}
 button {
   margin-top: 10px;
 }

--- a/extension/tests/dom-observer.test.js
+++ b/extension/tests/dom-observer.test.js
@@ -21,4 +21,61 @@ describe('DOMObserver', () => {
     expect(cb).toHaveBeenCalled();
     observer.cleanup();
   });
+
+  test('generates a run id when user starts typing in an empty conversation', async () => {
+    document.body.innerHTML = `
+      <div class="thread"></div>
+      <textarea class="composer"></textarea>
+    `;
+
+    const observer = new DOMObserver({
+      'conversation-capture': '.thread .message',
+      'input-detection': '.composer'
+    });
+
+    observer.start();
+
+    await Promise.resolve();
+    jest.advanceTimersByTime(300);
+
+    const input = document.querySelector('.composer');
+    input.dispatchEvent(new Event('input', { bubbles: true }));
+
+    const runId = observer.getCurrentRunId();
+    expect(runId).toMatch(/^thread_/);
+
+    input.dispatchEvent(new Event('input', { bubbles: true }));
+    expect(observer.getCurrentRunId()).toBe(runId);
+
+    observer.cleanup();
+  });
+
+  test('clears run id when conversation becomes empty again', async () => {
+    document.body.innerHTML = `
+      <div class="thread"><div class="message">Hello</div></div>
+      <textarea class="composer"></textarea>
+    `;
+
+    const observer = new DOMObserver({
+      'conversation-capture': '.thread .message',
+      'input-detection': '.composer'
+    });
+
+    observer.start();
+
+    await Promise.resolve();
+    jest.advanceTimersByTime(300);
+
+    observer.setCurrentRunId('thread_existing');
+
+    const container = document.querySelector('.thread');
+    container.innerHTML = '';
+
+    await Promise.resolve();
+    jest.advanceTimersByTime(300);
+
+    expect(observer.getCurrentRunId()).toBeNull();
+
+    observer.cleanup();
+  });
 });


### PR DESCRIPTION
## Summary
- replace the popup API token field with a project dropdown and persist the selection
- load projects from the backend during popup initialization and disable saving without a project
- remove API token storage/headers and adjust popup styles for the new dropdown

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cb6483a1188324acb493b938641244