### PR TITLE
Add OpenAI-powered console error analysis

### DIFF
--- a/backend/api/services/error_analysis.py
+++ b/backend/api/services/error_analysis.py
@@ -1,0 +1,153 @@
+"""Services for analyzing console errors with OpenAI."""
+
+from __future__ import annotations
+
+import json
+import logging
+from datetime import datetime
+from typing import Iterable, List, Mapping, MutableMapping, Optional
+
+from django.conf import settings
+from openai import OpenAI
+
+logger = logging.getLogger(__name__)
+
+
+class ErrorAnalysisConfigurationError(RuntimeError):
+    """Raised when the OpenAI client cannot be configured."""
+
+
+METAPROMPT = """You are Master Mind AI's automated debugger.
+Your task is to analyze JavaScript console errors captured from our browser extension and produce the exact code change that resolves the failure.
+
+Follow these steps carefully:
+1. Identify the primary error category. Use one of: DOM_SELECTOR, API_FAILURE, JS_RUNTIME, NETWORK, CONFIGURATION, PERMISSION, UNKNOWN.
+2. Decide which source file must be edited. Choose from only these areas:
+   - extension/content scripts (e.g. extension/content/*.js)
+   - backend Django views (e.g. backend/api/views/*.py)
+   - extension configuration (e.g. extension/shared/*.js or manifest files)
+3. Explain the root cause and outline the fix.
+4. Produce the complete updated code for the selected file. Do not provide diff markers—return the full file contents exactly as it should appear after the fix.
+
+Respond strictly with minified JSON using this structure:
+{
+  "error_type": "<CATEGORY>",
+  "target_file": "<relative/path/to/file>",
+  "explanation": "<one sentence summary>",
+  "resolution": {
+    "path": "<relative/path/to/file>",
+    "code": "<entire updated file contents>"
+  }
+}
+"""
+
+
+def analyze_console_errors(
+    entries: Iterable[Mapping[str, object]],
+    *,
+    platform: Optional[str] = None,
+    page_url: Optional[str] = None,
+    first_logged_at: Optional[datetime] = None,
+) -> str:
+    """Send console errors to OpenAI and return the structured response."""
+
+    api_key = getattr(settings, "OPENAI_API_KEY", "")
+    if not api_key:
+        raise ErrorAnalysisConfigurationError("OPENAI_API_KEY is not configured")
+
+    model = getattr(settings, "OPENAI_ERROR_MODEL", "gpt-4o-mini")
+    temperature_setting = getattr(settings, "OPENAI_ERROR_TEMPERATURE", 0.0)
+    try:
+        temperature = float(temperature_setting)
+    except (TypeError, ValueError):
+        logger.warning(
+            "Invalid OPENAI_ERROR_TEMPERATURE %s; falling back to 0.0",
+            temperature_setting,
+        )
+        temperature = 0.0
+
+    client = OpenAI(api_key=api_key)
+
+    prompt = _render_prompt(entries, platform=platform, page_url=page_url, first_logged_at=first_logged_at)
+
+    response = client.chat.completions.create(
+        model=model,
+        messages=[
+            {"role": "system", "content": METAPROMPT},
+            {"role": "user", "content": prompt},
+        ],
+        temperature=temperature,
+    )
+
+    choice = response.choices[0] if response.choices else None
+    if not choice or not choice.message or not choice.message.content:
+        raise RuntimeError("Empty response from OpenAI error analysis")
+
+    message_content = choice.message.content
+
+    _log_response_preview(message_content)
+
+    return message_content
+
+
+def _render_prompt(
+    entries: Iterable[Mapping[str, object]],
+    *,
+    platform: Optional[str],
+    page_url: Optional[str],
+    first_logged_at: Optional[datetime],
+) -> str:
+    """Format console error entries into a prompt payload."""
+
+    header: List[str] = [
+        "Analyze the following console.error events and respond with the required JSON only.",
+        f"Platform: {platform or 'unknown'}",
+        f"Page URL: {page_url or 'unknown'}",
+    ]
+    if first_logged_at:
+        header.append(f"First logged at: {first_logged_at.isoformat()}")
+
+    details: List[str] = []
+    for entry in entries:
+        timestamp = _as_timestamp(entry.get("timestamp"))
+        messages = entry.get("messages") or []
+        if not isinstance(messages, list):
+            messages = [str(messages)]
+        formatted_messages = " | ".join(str(msg) for msg in messages)
+        details.append(f"- {timestamp}: {formatted_messages}")
+
+    if not details:
+        details.append("- No console.error payload provided.")
+
+    return "\n".join(header + ["Errors:"] + details)
+
+
+def _as_timestamp(value: object) -> str:
+    """Render timestamp-like objects as ISO strings."""
+
+    if isinstance(value, datetime):
+        return value.isoformat()
+    if value is None:
+        return "unknown"
+    return str(value)
+
+
+def _log_response_preview(content: str) -> None:
+    """Emit a short preview of the OpenAI response for traceability."""
+
+    try:
+        parsed = json.loads(content)
+    except json.JSONDecodeError:
+        logger.debug("OpenAI analysis response is not JSON; raw content logged")
+        preview: MutableMapping[str, object] = {"raw": content[:200]}
+    else:
+        preview = {k: parsed.get(k) for k in ("error_type", "target_file")}
+
+    logger.info("Console error analysis response", extra={"preview": preview})
+
+
+__all__ = [
+    "ErrorAnalysisConfigurationError",
+    "analyze_console_errors",
+]
+

--- a/backend/mastermind/settings.py
+++ b/backend/mastermind/settings.py
@@ -138,6 +138,13 @@ MEM0_USE_PROXY_CLIENT = config("MEM0_USE_PROXY_CLIENT", cast=bool, default=True)
 MEM0_CHAT_MODEL = config("MEM0_CHAT_MODEL", default="gpt-4o-mini")
 MEM0_CHAT_TEMPERATURE = config("MEM0_CHAT_TEMPERATURE", cast=float, default=0.0)
 
+# OpenAI configuration for console error analysis
+OPENAI_API_KEY = config("OPENAI_API_KEY", default="")
+OPENAI_ERROR_MODEL = config("OPENAI_ERROR_MODEL", default="gpt-4o-mini")
+OPENAI_ERROR_TEMPERATURE = config(
+    "OPENAI_ERROR_TEMPERATURE", cast=float, default=0.0
+)
+
 ENVIRONMENT = config("ENVIRONMENT", default="development")
 CORS_ALLOW_CREDENTIALS = True
 

--- a/backend/tests/test_console_logs_endpoint.py
+++ b/backend/tests/test_console_logs_endpoint.py
@@ -7,12 +7,16 @@ from unittest.mock import patch
 
 from django.test import TestCase
 
+from api.services.error_analysis import ErrorAnalysisConfigurationError
+
 
 class ConsoleLogsEndpointTests(TestCase):
     """Verify console log batches can be ingested."""
 
+    @patch("api.views.logs.analyze_console_errors")
     @patch("api.views.logs.logger")
-    def test_console_logs_ingested_successfully(self, mock_logger) -> None:
+    def test_console_logs_ingested_successfully(self, mock_logger, mock_analyze) -> None:
+        mock_analyze.return_value = "{\"target_file\": \"extension/content/app.js\"}"
         payload = {
             "platform": "chatgpt",
             "page_url": "https://chat.openai.com/",
@@ -34,7 +38,8 @@ class ConsoleLogsEndpointTests(TestCase):
 
         self.assertEqual(response.status_code, 202)
         self.assertEqual(response.json(), {"status": "accepted", "entries": 1})
-        mock_logger.info.assert_called_once()
+        mock_analyze.assert_called_once()
+        self.assertEqual(mock_logger.info.call_count, 2)
         mock_logger.log.assert_called_once()
 
     def test_console_logs_missing_entries_returns_error(self) -> None:
@@ -46,3 +51,31 @@ class ConsoleLogsEndpointTests(TestCase):
 
         self.assertEqual(response.status_code, 400)
         self.assertIn("entries", response.json())
+
+    @patch("api.views.logs.analyze_console_errors", side_effect=ErrorAnalysisConfigurationError("missing"))
+    @patch("api.views.logs.logger")
+    def test_console_error_analysis_skipped_when_unconfigured(
+        self, mock_logger, mock_analyze
+    ) -> None:
+        payload = {
+            "platform": "chatgpt",
+            "page_url": "https://chat.openai.com/",
+            "first_logged_at": datetime.now(timezone.utc).isoformat(),
+            "entries": [
+                {
+                    "level": "error",
+                    "timestamp": datetime.now(timezone.utc).isoformat(),
+                    "messages": ["ReferenceError: foo is not defined"],
+                }
+            ],
+        }
+
+        response = self.client.post(
+            "/api/debug-logs/",
+            data=payload,
+            content_type="application/json",
+        )
+
+        self.assertEqual(response.status_code, 202)
+        mock_analyze.assert_called_once()
+        mock_logger.debug.assert_called_once()

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -10,6 +10,7 @@
     -H "Content-Type: application/json" \
     -d '{"platform":"chatgpt","entries":[{"level":"log","timestamp":"2024-01-01T00:00:00Z","messages":["test"]}]}'
   ```
+- Optional: set `OPENAI_API_KEY` to allow automatic console error analysis responses in the API logs.
 
 ## Browser Extension
 - Install Node dependencies: `cd extension && npm install`

--- a/env.example
+++ b/env.example
@@ -31,6 +31,11 @@ MEM0_USE_PROXY_CLIENT=True  # Toggle Mem0 proxy client integration
 MEM0_CHAT_MODEL=gpt-4o-mini  # Model used for chat completions
 MEM0_CHAT_TEMPERATURE=0.0  # Temperature for chat completions
 
+# OpenAI Error Analysis
+OPENAI_API_KEY=your-openai-api-key  # API key for OpenAI error analysis
+OPENAI_ERROR_MODEL=gpt-4o-mini  # Model used for debugging automation
+OPENAI_ERROR_TEMPERATURE=0.0  # Temperature used when requesting fixes
+
 # CORS Settings for Browser Extension
 CORS_ALLOWED_ORIGINS=chrome-extension://<extension-id>  # Extension origin allowed to access the API
 


### PR DESCRIPTION
## Summary
- add an OpenAI-backed error analysis service that constructs the debugging metaprompt and formats console error payloads
- invoke the analyzer from the console log ingestion view to capture structured fixes when errors are reported and log the response
- document the new configuration variables and ensure tests cover configured and unconfigured analyzer paths

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ced5ae29608324a2f1641a3d358519