### PR TITLE
Update popup workflow for user and project management

### DIFF
--- a/extension/api.js
+++ b/extension/api.js
@@ -50,6 +50,14 @@ class APIClient {
     return this.request(`/api/v1/projects/${query}`, { baseUrl });
   }
 
+  createProject(baseUrl, payload) {
+    return this.request('/api/v1/projects/', {
+      method: 'POST',
+      body: JSON.stringify(payload),
+      baseUrl
+    });
+  }
+
   saveConversation(payload) {
     return this.request('/api/v1/conversations/', {
       method: 'POST',

--- a/extension/popup.html
+++ b/extension/popup.html
@@ -15,9 +15,14 @@
   </label>
   <div class="form-group">
     <label for="project-select">Project:</label>
-    <select id="project-select" required>
-      <option value="">Select project...</option>
+    <select id="project-select" required disabled>
+      <option value="">Save user ID to load projects</option>
     </select>
+    <div id="project-loading" class="loading-indicator" hidden>Loading projects...</div>
+  </div>
+  <div class="form-group" id="new-project-container" hidden>
+    <label for="new-project-name">New project name</label>
+    <input id="new-project-name" type="text" placeholder="Project name" />
   </div>
   <label>User ID
     <input id="userId" type="text" placeholder="user" />

--- a/extension/popup.js
+++ b/extension/popup.js
@@ -3,14 +3,21 @@ import { apiClient } from './api.js';
 
 const envEl = document.getElementById('environment');
 const projectEl = document.getElementById('project-select');
+const projectLoadingEl = document.getElementById('project-loading');
 const userIdEl = document.getElementById('userId');
 const statusEl = document.getElementById('status');
 const connectionEl = document.getElementById('connection');
 const saveButton = document.getElementById('save');
+const newProjectContainer = document.getElementById('new-project-container');
+const newProjectInput = document.getElementById('new-project-name');
+
+const ADD_NEW_PROJECT_OPTION = '__add_new_project__';
+const USER_ID_PROMPT_MESSAGE = 'Enter User ID first to load projects';
 
 let statusTimeoutId;
+let userIdSaved = false;
 
-function showStatus(message, isError = false) {
+function showStatus(message, isError = false, { persist = false } = {}) {
   statusEl.textContent = message;
   statusEl.style.color = isError ? 'red' : 'green';
 
@@ -19,7 +26,7 @@ function showStatus(message, isError = false) {
     statusTimeoutId = null;
   }
 
-  if (message && !isError) {
+  if (message && !isError && !persist) {
     statusTimeoutId = setTimeout(() => {
       statusEl.textContent = '';
       statusTimeoutId = null;
@@ -27,9 +34,53 @@ function showStatus(message, isError = false) {
   }
 }
 
+function setProjectPlaceholder(message) {
+  projectEl.innerHTML = `<option value="">${message}</option>`;
+  projectEl.value = '';
+}
+
+function toggleProjectLoading(isLoading) {
+  if (projectLoadingEl) {
+    projectLoadingEl.hidden = !isLoading;
+  }
+  projectEl.classList.toggle('loading', isLoading);
+}
+
+function hideNewProjectInput() {
+  if (newProjectContainer) {
+    newProjectContainer.hidden = true;
+  }
+  if (newProjectInput) {
+    newProjectInput.value = '';
+  }
+}
+
 function updateSaveButtonState() {
   const userId = userIdEl.value.trim();
-  saveButton.disabled = projectEl.disabled || !projectEl.value || !userId;
+  const selectedProject = projectEl.value;
+  const isAddingNewProject = selectedProject === ADD_NEW_PROJECT_OPTION;
+  const newProjectName = newProjectInput?.value.trim() ?? '';
+
+  if (!userId) {
+    saveButton.disabled = true;
+    saveButton.textContent = 'Save';
+    return;
+  }
+
+  if (projectEl.disabled) {
+    saveButton.disabled = false;
+    saveButton.textContent = 'Save User ID';
+    return;
+  }
+
+  if (isAddingNewProject) {
+    saveButton.disabled = !newProjectName;
+    saveButton.textContent = 'Create Project';
+    return;
+  }
+
+  saveButton.disabled = !selectedProject;
+  saveButton.textContent = 'Save';
 }
 
 async function loadProjects(selectedProjectId = '') {
@@ -37,21 +88,27 @@ async function loadProjects(selectedProjectId = '') {
   const baseUrl = ENVIRONMENTS[environment] || ENVIRONMENTS.production;
   const userId = userIdEl.value.trim();
 
+  hideNewProjectInput();
   projectEl.disabled = true;
   if (!userId) {
-    projectEl.innerHTML = '<option value="">Enter user ID to load projects</option>';
+    toggleProjectLoading(false);
+    setProjectPlaceholder('Save user ID to load projects');
+    showStatus(USER_ID_PROMPT_MESSAGE, false, { persist: true });
     updateSaveButtonState();
     return;
   }
 
-  projectEl.innerHTML = '<option value="">Loading projects...</option>';
+  toggleProjectLoading(true);
+  setProjectPlaceholder('Loading projects...');
   updateSaveButtonState();
+
+  let loaded = false;
 
   try {
     const response = await apiClient.fetchProjects(baseUrl, userId);
     const projects = Array.isArray(response) ? response : response?.results || [];
 
-    projectEl.innerHTML = '<option value="">Select project...</option>';
+    setProjectPlaceholder('Select project...');
 
     projects.forEach(project => {
       const option = document.createElement('option');
@@ -59,6 +116,11 @@ async function loadProjects(selectedProjectId = '') {
       option.textContent = project.name;
       projectEl.appendChild(option);
     });
+
+    const addOption = document.createElement('option');
+    addOption.value = ADD_NEW_PROJECT_OPTION;
+    addOption.textContent = 'Add New Project';
+    projectEl.appendChild(addOption);
 
     if (selectedProjectId) {
       const matched = projects.find(project => String(project.id) === String(selectedProjectId));
@@ -68,18 +130,20 @@ async function loadProjects(selectedProjectId = '') {
         projectEl.value = '';
         showStatus('Saved project is unavailable. Please choose another project.', true);
       }
+    } else {
+      projectEl.value = '';
     }
 
-    if (!projects.length) {
-      showStatus('No projects available.', true);
-    }
+    showStatus(`Loaded ${projects.length} project${projects.length === 1 ? '' : 's'}`);
+    loaded = true;
+    projectEl.disabled = false;
   } catch (error) {
     console.error('Failed to load projects', error);
-    projectEl.innerHTML = '<option value="">Select project...</option>';
-    projectEl.value = '';
+    setProjectPlaceholder('Select project...');
     showStatus('Failed to load projects', true);
   } finally {
-    projectEl.disabled = false;
+    toggleProjectLoading(false);
+    projectEl.disabled = !loaded;
     updateSaveButtonState();
   }
 }
@@ -97,7 +161,15 @@ async function init() {
   const { environment, userId, projectId } = await getSettings();
   envEl.value = environment;
   userIdEl.value = userId;
-  await loadProjects(projectId);
+  userIdSaved = Boolean(userId);
+
+  if (userId) {
+    await loadProjects(projectId);
+  } else {
+    setProjectPlaceholder('Save user ID to load projects');
+    showStatus(USER_ID_PROMPT_MESSAGE, false, { persist: true });
+  }
+
   updateConnection();
   updateSaveButtonState();
 }
@@ -105,37 +177,125 @@ async function init() {
 init();
 
 envEl.addEventListener('change', () => {
-  loadProjects(projectEl.value);
+  hideNewProjectInput();
+
+  if (userIdSaved) {
+    const selectedProjectId =
+      projectEl.value && projectEl.value !== ADD_NEW_PROJECT_OPTION ? projectEl.value : '';
+    loadProjects(selectedProjectId);
+  } else {
+    setProjectPlaceholder('Save user ID to load projects');
+    showStatus(USER_ID_PROMPT_MESSAGE, false, { persist: true });
+    updateSaveButtonState();
+  }
 });
 
 projectEl.addEventListener('change', () => {
-  if (statusEl.style.color === 'red' && statusEl.textContent) {
-    showStatus('');
+  const isAddingNewProject = projectEl.value === ADD_NEW_PROJECT_OPTION;
+
+  if (isAddingNewProject) {
+    if (newProjectContainer) {
+      newProjectContainer.hidden = false;
+    }
+    if (newProjectInput) {
+      newProjectInput.focus();
+    }
+  } else {
+    if (statusEl.style.color === 'red' && statusEl.textContent) {
+      showStatus('');
+    }
+    hideNewProjectInput();
   }
+
   updateSaveButtonState();
 });
 
-saveButton.addEventListener('click', () => {
-  if (!projectEl.value || !userIdEl.value.trim()) {
+saveButton.addEventListener('click', async () => {
+  const userId = userIdEl.value.trim();
+
+  if (!userId) {
     updateSaveButtonState();
     return;
   }
 
-  setSettings({ environment: envEl.value, userId: userIdEl.value, projectId: projectEl.value })
-    .then(() => {
-      showStatus('Saved');
-      updateConnection();
-    })
-    .catch(error => {
-      console.error('Failed to save settings', error);
-      showStatus('Failed to save settings', true);
-    });
-});
+  const environment = envEl.value;
+  const baseUrl = ENVIRONMENTS[environment] || ENVIRONMENTS.production;
+  const selectedProject = projectEl.value;
+  const isAddingNewProject = selectedProject === ADD_NEW_PROJECT_OPTION;
 
-userIdEl.addEventListener('blur', () => {
-  loadProjects(projectEl.value);
+  saveButton.disabled = true;
+
+  try {
+    if (projectEl.disabled) {
+      await setSettings({ environment, userId, projectId: '' });
+      userIdSaved = true;
+      showStatus('User ID saved. Loading projects...', false, { persist: true });
+      await loadProjects();
+      updateConnection();
+      return;
+    }
+
+    if (isAddingNewProject) {
+      const newProjectName = newProjectInput?.value.trim() ?? '';
+
+      if (!newProjectName) {
+        showStatus('Enter a project name to continue.', true);
+        return;
+      }
+
+      showStatus('Creating project...', false, { persist: true });
+      const createdProject = await apiClient.createProject(baseUrl, {
+        name: newProjectName,
+        user_id: userId
+      });
+
+      const createdProjectId = createdProject?.id ? String(createdProject.id) : '';
+      hideNewProjectInput();
+
+      await loadProjects(createdProjectId);
+
+      if (createdProjectId) {
+        await setSettings({ environment, userId, projectId: createdProjectId });
+      } else {
+        await setSettings({ environment, userId, projectId: '' });
+      }
+
+      userIdSaved = true;
+
+      showStatus('Project created and saved.', false);
+      updateConnection();
+      return;
+    }
+
+    if (!selectedProject) {
+      showStatus('Select a project to save.', true);
+      return;
+    }
+
+    await setSettings({ environment, userId, projectId: selectedProject });
+    userIdSaved = true;
+    showStatus('Saved');
+    updateConnection();
+  } catch (error) {
+    console.error('Failed to save settings', error);
+    showStatus('Failed to save settings', true);
+  } finally {
+    updateSaveButtonState();
+  }
 });
 
 userIdEl.addEventListener('input', () => {
+  userIdSaved = false;
+  hideNewProjectInput();
+  setProjectPlaceholder('Save user ID to load projects');
+  toggleProjectLoading(false);
+  projectEl.disabled = true;
+  if (statusEl.textContent !== USER_ID_PROMPT_MESSAGE) {
+    showStatus(USER_ID_PROMPT_MESSAGE, false, { persist: true });
+  }
+  updateSaveButtonState();
+});
+
+newProjectInput?.addEventListener('input', () => {
   updateSaveButtonState();
 });

--- a/extension/styles.css
+++ b/extension/styles.css
@@ -17,6 +17,25 @@ select {
   box-sizing: border-box;
 }
 
+.loading-indicator {
+  margin-top: 4px;
+  font-size: 12px;
+  color: #555;
+}
+
+.loading-indicator[hidden] {
+  display: none;
+}
+
+.loading {
+  opacity: 0.6;
+}
+
+.form-group select:disabled {
+  background-color: #f0f0f0;
+  color: #666;
+}
+
 .form-group {
   margin-bottom: 8px;
 }


### PR DESCRIPTION
## Summary
- gate project loading on a saved user ID and provide clearer status messaging and loading states
- add an inline flow for creating projects from the popup and refresh the list after creation
- refine save button behavior to support staged saving of the user ID and project selection

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cfb3afcf008324867989da0523c3b7