### PR TITLE
Improve project creation flow in popup

### DIFF
--- a/extension/popup.html
+++ b/extension/popup.html
@@ -23,6 +23,7 @@
   <div class="form-group" id="new-project-container" hidden>
     <label for="new-project-name">New project name</label>
     <input id="new-project-name" type="text" placeholder="Project name" />
+    <div id="new-project-feedback" class="validation-message" hidden></div>
   </div>
   <label>User ID
     <input id="userId" type="text" placeholder="user" />

--- a/extension/styles.css
+++ b/extension/styles.css
@@ -51,3 +51,13 @@ button {
   margin-top: 10px;
   color: green;
 }
+
+.validation-message {
+  margin-top: 4px;
+  font-size: 12px;
+  color: #d93025;
+}
+
+.validation-message[hidden] {
+  display: none;
+}


### PR DESCRIPTION
## Summary
- add inline validation for new project names and surface helpful error messaging
- improve project loading/creation flow to auto-select created projects and handle missing IDs
- enhance popup styling to display validation feedback

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d01b502e4c8324b76a5a40bbd161a8