### PR TITLE
Run migrations during container startup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -46,5 +46,5 @@ COPY --from=build /app /app
 ENV PORT=8000
 EXPOSE $PORT
 
-# Gunicorn startup command uses Render's PORT environment variable
-CMD gunicorn mastermind.wsgi:application --bind 0.0.0.0:$PORT
+# Run database migrations before starting Gunicorn using Render's PORT environment variable
+CMD sh -c "python manage.py migrate --noinput && gunicorn mastermind.wsgi:application --bind 0.0.0.0:$PORT"


### PR DESCRIPTION
## Summary
- ensure the Django application runs database migrations before starting Gunicorn by updating the Docker startup command

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d11913cc9c8324bbbdd3ca128fd0d1