### PR TITLE
Inject stored user ID for assignment creation

### DIFF
--- a/backend/api/serializers.py
+++ b/backend/api/serializers.py
@@ -20,6 +20,9 @@ class UserProfileSerializer(serializers.ModelSerializer):
 class AssignmentSerializer(serializers.ModelSerializer):
     """Serializer for assignments."""
 
+    owner = serializers.PrimaryKeyRelatedField(
+        queryset=User.objects.all(), required=False, allow_null=True
+    )
     app_id = serializers.RegexField(
         regex=r"^[A-Za-z0-9]{8}$",
         max_length=8,

--- a/backend/tests/test_assignment_api.py
+++ b/backend/tests/test_assignment_api.py
@@ -1,0 +1,38 @@
+"""Tests for the assignment API endpoints."""
+from django.contrib.auth.models import User
+from django.test import TestCase
+from rest_framework import status
+
+from api.models import Assignment, UserProfile
+
+
+class AssignmentAPITests(TestCase):
+    """Verify assignment creation resolves owners to ``User`` instances."""
+
+    def setUp(self) -> None:
+        self.user = User.objects.create_user(username='owner', password='password123')
+        self.profile = UserProfile.objects.create(user=self.user)
+
+    def test_assignment_creation_uses_user_owner(self) -> None:
+        payload = {
+            'name': 'NewAssign',
+            'app_id': 'ABCDEFGH',
+            'user_id': self.profile.pk,
+        }
+
+        response = self.client.post(
+            '/api/v1/assignments/',
+            data=payload,
+            content_type='application/json',
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+
+        data = response.json()
+        assignment = Assignment.objects.get(pk=data['id'])
+
+        self.assertEqual(assignment.owner, self.user)
+        self.assertEqual(assignment.owner_id, self.user.id)
+        self.assertEqual(data['owner'], self.user.id)
+        self.assertIsInstance(assignment.owner, User)
+        self.assertEqual(Assignment.objects.count(), 1)

--- a/extension/api.js
+++ b/extension/api.js
@@ -50,7 +50,10 @@ class APIClient {
     return this.request(`/api/v1/assignments/${query}`, { baseUrl });
   }
 
-  createAssignment(baseUrl, payload) {
+  async createAssignment(baseUrl, payload = {}) {
+    const { userId } = await getSettings();
+    payload.user_id = userId;
+
     return this.request('/api/v1/assignments/', {
       method: 'POST',
       body: JSON.stringify(payload),

--- a/extension/popup.js
+++ b/extension/popup.js
@@ -350,8 +350,7 @@ saveButton.addEventListener('click', async () => {
       setAssignmentNameFeedback('');
       showStatus('Creating assignment...', false, { persist: true });
       const createdAssignment = await apiClient.createAssignment(baseUrl, {
-        name: normalizedName,
-        user_id: userId
+        name: normalizedName
       });
 
       const createdAssignmentId = createdAssignment?.id ? String(createdAssignment.id) : '';

--- a/extension/tests/api.test.js
+++ b/extension/tests/api.test.js
@@ -1,0 +1,72 @@
+import { jest } from '@jest/globals';
+
+const originalConsoleError = console.error;
+
+function createFetchResponse(body = {}, status = 200) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => body,
+    text: async () => JSON.stringify(body)
+  };
+}
+
+describe('APIClient.createAssignment', () => {
+  let apiClient;
+  let mockGetSettings;
+
+  beforeEach(async () => {
+    jest.resetModules();
+    console.error = jest.fn();
+    mockGetSettings = jest.fn().mockResolvedValue({
+      userId: 'user-123',
+      apiBaseUrl: 'https://default.example'
+    });
+    global.fetch = jest.fn().mockResolvedValue(createFetchResponse({ id: 1 }, 201));
+
+    await jest.unstable_mockModule('../config.js', () => ({
+      getSettings: mockGetSettings
+    }));
+
+    ({ apiClient } = await import('../api.js'));
+  });
+
+  afterEach(() => {
+    delete global.fetch;
+    jest.resetModules();
+    jest.clearAllMocks();
+    console.error = originalConsoleError;
+  });
+
+  test('injects the stored user id into the assignment payload', async () => {
+    const payload = { name: 'NewAssign', user_id: 'malicious-user' };
+
+    await apiClient.createAssignment('https://custom.example', payload);
+
+    expect(mockGetSettings).toHaveBeenCalled();
+    expect(fetch).toHaveBeenCalledTimes(1);
+
+    const [requestUrl, options] = fetch.mock.calls[0];
+    expect(requestUrl).toBe('https://custom.example/api/v1/assignments/');
+
+    const body = JSON.parse(options.body);
+    expect(body).toEqual({ name: 'NewAssign', user_id: 'user-123' });
+    expect(payload.user_id).toBe('user-123');
+  });
+
+  test('falls back to the configured base URL when none is provided', async () => {
+    mockGetSettings.mockResolvedValue({
+      userId: 'user-abc',
+      apiBaseUrl: 'https://fallback.example'
+    });
+
+    await apiClient.createAssignment(undefined, { name: 'AnotherOne' });
+
+    expect(fetch).toHaveBeenCalledTimes(1);
+    const [requestUrl, options] = fetch.mock.calls[0];
+    expect(requestUrl).toBe('https://fallback.example/api/v1/assignments/');
+
+    const body = JSON.parse(options.body);
+    expect(body).toEqual({ name: 'AnotherOne', user_id: 'user-abc' });
+  });
+});

--- a/extension/tests/popup.test.js
+++ b/extension/tests/popup.test.js
@@ -1,0 +1,118 @@
+import { jest } from '@jest/globals';
+
+const ADD_NEW_ASSIGNMENT_OPTION = '__add_new_assignment__';
+
+function setupDom() {
+  document.body.innerHTML = `
+    <select id="environment">
+      <option value="production">Production</option>
+      <option value="development">Development</option>
+    </select>
+    <select id="assignment-select"></select>
+    <div id="assignment-loading" hidden></div>
+    <div id="new-assignment-container" hidden></div>
+    <input id="new-assignment-name" type="text" />
+    <div id="new-assignment-feedback" hidden></div>
+    <input id="userId" type="text" />
+    <button id="save">Save</button>
+    <div id="connection"></div>
+    <div id="status"></div>
+  `;
+}
+
+async function flushPromises() {
+  return new Promise(resolve => setTimeout(resolve, 0));
+}
+
+describe('popup assignment creation flow', () => {
+  let mockGetSettings;
+  let mockSetSettings;
+  let mockCreateAssignment;
+  let mockFetchAssignments;
+
+  beforeEach(async () => {
+    jest.resetModules();
+    setupDom();
+
+    global.chrome = {
+      runtime: {
+        sendMessage: jest.fn((message, callback) => {
+          if (typeof callback === 'function') {
+            callback({ ok: true });
+          }
+        })
+      }
+    };
+
+    mockGetSettings = jest.fn().mockResolvedValue({
+      environment: 'production',
+      userId: 'user-123',
+      assignmentId: ''
+    });
+    mockSetSettings = jest.fn().mockResolvedValue(undefined);
+    mockCreateAssignment = jest.fn().mockResolvedValue({ id: 10, name: 'NewAssign1' });
+    mockFetchAssignments = jest
+      .fn()
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([{ id: 10, name: 'NewAssign1' }])
+      .mockResolvedValue([]);
+
+    await jest.unstable_mockModule('../config.js', () => ({
+      ENVIRONMENTS: {
+        production: 'https://api.example',
+        development: 'http://localhost:8000'
+      },
+      getSettings: mockGetSettings,
+      setSettings: mockSetSettings
+    }));
+
+    await jest.unstable_mockModule('../api.js', () => ({
+      apiClient: {
+        fetchAssignments: mockFetchAssignments,
+        createAssignment: mockCreateAssignment
+      }
+    }));
+
+    await import('../popup.js');
+    await flushPromises();
+  });
+
+  afterEach(() => {
+    delete global.chrome;
+    jest.resetModules();
+    jest.clearAllMocks();
+    document.body.innerHTML = '';
+  });
+
+  test('creates a new assignment and saves the selection', async () => {
+    const assignmentSelect = document.getElementById('assignment-select');
+    const newAssignmentInput = document.getElementById('new-assignment-name');
+    const saveButton = document.getElementById('save');
+
+    assignmentSelect.value = ADD_NEW_ASSIGNMENT_OPTION;
+    assignmentSelect.dispatchEvent(new Event('change'));
+
+    newAssignmentInput.value = 'NewAssign1';
+    newAssignmentInput.dispatchEvent(new Event('input'));
+
+    saveButton.click();
+
+    await flushPromises();
+    await flushPromises();
+
+    expect(mockCreateAssignment).toHaveBeenCalledWith('https://api.example', {
+      name: 'NewAssign1'
+    });
+
+    expect(mockFetchAssignments).toHaveBeenCalledTimes(2);
+    expect(mockFetchAssignments).toHaveBeenLastCalledWith('https://api.example', 'user-123');
+
+    expect(mockSetSettings).toHaveBeenCalledWith({
+      environment: 'production',
+      userId: 'user-123',
+      assignmentId: '10'
+    });
+
+    expect(assignmentSelect.value).toBe('10');
+  });
+});


### PR DESCRIPTION
## Summary
- ensure the extension API client injects the stored user id when creating assignments
- update the popup assignment flow and add browser extension unit tests
- allow missing owner data in the assignment serializer and add a regression test for user ownership

## Testing
- npm test
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d16aa105c883249c883061bcddb272