### PR TITLE
Implement multi-level prompt enhancement pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Deployment steps and security practices are described in [`docs/deployment.md`](
 - `GET /api/v1/health/` – Service health check
 - `POST /api/v1/conversations/` – Store a conversation
 - `POST /api/v1/conversations/search/` – Search stored memories (requires `query` and `user_id`)
-- `POST /api/v1/prompts/enhance/` – Enhance a prompt with relevant memories (requires `prompt` and `user_id`)
+- `POST /api/v1/prompts/enhance/` – Enhance a prompt with relevant memories (requires `prompt` and `user_id`; accepts optional `app_id` and `run_id` for richer context)
 
 ## Technology Stack
 - Django

--- a/backend/api/views/enhancement.py
+++ b/backend/api/views/enhancement.py
@@ -25,13 +25,22 @@ def enhance_prompt(request):
 
     prompt = data.get("prompt")
     user_id = data.get("user_id")
+    app_id = data.get("app_id")
+    run_id = data.get("run_id")
     if not prompt:
         return JsonResponse({"detail": "prompt is required"}, status=400)
     if not user_id:
         return JsonResponse({"detail": "user_id is required"}, status=400)
 
     try:
-        enhanced = MemoryService().enhance_prompt(prompt, user_id=user_id)
+        service = MemoryService()
+        cleaned_prompt = service.openai_light_cleanup(prompt)
+        enhanced = service.multi_level_memory_search(
+            cleaned_prompt,
+            user_id=user_id,
+            app_id=app_id,
+            run_id=run_id,
+        )
         return JsonResponse({"enhanced_prompt": enhanced})
     except APIError as exc:  # pragma: no cover - external dependency
         logger.error("Prompt enhancement failed: %s", exc)


### PR DESCRIPTION
## Summary
- route prompt enhancement requests through a cleanup step and a multi-level memory search that accepts app_id and run_id metadata
- extend the memory service with helper methods to sanitize prompts and retrieve both personal and documentation context before invoking chat enhancement
- update endpoint tests and README documentation to reflect the new pipeline and accepted parameters

## Testing
- pytest backend/tests/test_enhancement_endpoint.py

------
https://chatgpt.com/codex/tasks/task_e_68d16f7675288324946829f717d7e336