### PR TITLE
Add FastAPI environment options to extension config

### DIFF
--- a/extension/config.js
+++ b/extension/config.js
@@ -1,6 +1,8 @@
 export const ENVIRONMENTS = {
-  development: 'http://localhost:8000',
-  production: 'https://master-mind-ai.onrender.com'
+  development: 'http://localhost:8000', // FastAPI local testing
+  production: 'https://master-mind-ai.onrender.com', // Django production
+  fastapi: 'http://localhost:8000', // FastAPI explicit
+  django: 'https://master-mind-ai.onrender.com' // Django fallback
 };
 
 export function getSettings() {


### PR DESCRIPTION
## Summary
- extend the browser extension configuration environments to support both FastAPI and Django backends
- annotate the configuration entries to clarify which targets support FastAPI testing versus Django production

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d39698c8f88324a619ebc647a41542