### PR TITLE
Update assignment creation payload to use appid

### DIFF
--- a/extension/popup.js
+++ b/extension/popup.js
@@ -112,10 +112,10 @@ function validateAssignmentName(name) {
     return { valid: false, message: 'App ID must be alphanumeric.', normalizedName: '' };
   }
 
-  if (trimmedName.length !== 8) {
+  if (!/^[A-Za-z0-9]{8,}$/.test(trimmedName)) {
     return {
       valid: false,
-      message: 'App ID must be exactly 8 characters.',
+      message: 'App ID must be at least 8 characters.',
       normalizedName: ''
     };
   }
@@ -411,8 +411,7 @@ saveButton.addEventListener('click', async () => {
 
       const desiredAppId = normalizedName;
       const createdAssignment = await apiClient.createAssignment(baseUrl, {
-        name: desiredAppId,
-        app_id: desiredAppId
+        appid: desiredAppId
       });
 
       const createdAssignmentId = createdAssignment?.id ? String(createdAssignment.id) : '';

--- a/extension/tests/api.test.js
+++ b/extension/tests/api.test.js
@@ -40,7 +40,7 @@ describe('APIClient.createAssignment', () => {
   });
 
   test('injects the stored user id into the assignment payload', async () => {
-    const payload = { name: 'NewAssign', user_id: 'malicious-user', app_id: 'ABCDEFGH' };
+    const payload = { appid: 'ABCDEFGH', user_id: 'malicious-user' };
 
     await apiClient.createAssignment('https://custom.example', payload);
 
@@ -54,9 +54,9 @@ describe('APIClient.createAssignment', () => {
     expect(options.headers['X-App-Id']).toBe('app-xyz');
 
     const body = JSON.parse(options.body);
-    expect(body).toEqual({ name: 'NewAssign', user_id: 'user-123', app_id: 'ABCDEFGH' });
+    expect(body).toEqual({ appid: 'ABCDEFGH', user_id: 'user-123' });
     expect(payload.user_id).toBe('user-123');
-    expect(payload.app_id).toBe('ABCDEFGH');
+    expect(payload.appid).toBe('ABCDEFGH');
   });
 
   test('falls back to the configured base URL when none is provided', async () => {
@@ -66,13 +66,13 @@ describe('APIClient.createAssignment', () => {
       apiBaseUrl: 'https://fallback.example'
     });
 
-    await apiClient.createAssignment(undefined, { name: 'AnotherOne', app_id: 'HGFEDCBA' });
+    await apiClient.createAssignment(undefined, { appid: 'HGFEDCBA' });
 
     expect(fetch).toHaveBeenCalledTimes(1);
     const [requestUrl, options] = fetch.mock.calls[0];
     expect(requestUrl).toBe('https://fallback.example/api/v1/assignments/');
 
     const body = JSON.parse(options.body);
-    expect(body).toEqual({ name: 'AnotherOne', user_id: 'user-abc', app_id: 'HGFEDCBA' });
+    expect(body).toEqual({ appid: 'HGFEDCBA', user_id: 'user-abc' });
   });
 });

--- a/extension/tests/popup.test.js
+++ b/extension/tests/popup.test.js
@@ -53,8 +53,8 @@ describe('popup assignment creation flow', () => {
     mockSetSettings = jest.fn().mockResolvedValue(undefined);
     createdAppId = '';
     mockCreateAssignment = jest.fn().mockImplementation((_baseUrl, payload) => {
-      createdAppId = payload.app_id;
-      return Promise.resolve({ id: 10, name: 'NewApp01', app_id: payload.app_id });
+      createdAppId = payload.appid;
+      return Promise.resolve({ id: 10, name: 'NewApp01', app_id: payload.appid });
     });
     mockFetchUserAppIds = jest
       .fn()
@@ -107,8 +107,7 @@ describe('popup assignment creation flow', () => {
 
     expect(mockCreateAssignment).toHaveBeenCalledTimes(1);
     const [, createPayload] = mockCreateAssignment.mock.calls[0];
-    expect(createPayload.name).toBe('NewApp01');
-    expect(createPayload.app_id).toBe('NewApp01');
+    expect(createPayload).toEqual({ appid: 'NewApp01' });
 
     expect(mockFetchUserAppIds).toHaveBeenCalledTimes(2);
     expect(mockFetchUserAppIds).toHaveBeenLastCalledWith('https://api.example', 'user-123');
@@ -116,9 +115,9 @@ describe('popup assignment creation flow', () => {
     expect(mockSetSettings).toHaveBeenCalledWith({
       environment: 'production',
       userId: 'user-123',
-      appId: createPayload.app_id
+      appId: 'NewApp01'
     });
 
-    expect(assignmentSelect.value).toBe(createPayload.app_id);
+    expect(assignmentSelect.value).toBe('NewApp01');
   });
 });


### PR DESCRIPTION
## Summary
- update the popup assignment validation to allow alphanumeric IDs with eight or more characters
- send the new appid field when creating assignments from the popup
- adjust tests to reflect the new payload shape and validation requirements

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d3d0ba403c83248f7a9830e2da189d