### PR TITLE
Simplify FastAPI health check

### DIFF
--- a/backend-v2/README.md
+++ b/backend-v2/README.md
@@ -4,7 +4,7 @@ This directory contains the experimental FastAPI implementation of the Master Mi
 
 ## Features
 
-- Health check and readiness endpoint
+- Lightweight health check endpoint that avoids Mem0 calls
 - User app ID discovery via Mem0
 - Assignment namespace initialisation without a relational database
 - Two-stage prompt enhancement using Mem0 memories and OpenAI chat completions

--- a/backend-v2/app/models.py
+++ b/backend-v2/app/models.py
@@ -62,7 +62,6 @@ class HealthResponse(BaseModel):
 
     status: str
     service: str
-    mem0_connected: bool
     timestamp: datetime
 
 

--- a/backend-v2/app/routers/health.py
+++ b/backend-v2/app/routers/health.py
@@ -4,10 +4,9 @@ from __future__ import annotations
 
 from datetime import datetime
 
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter
 
 from app.models import HealthResponse
-from app.services.memory import AsyncMemoryService
 
 
 router = APIRouter(tags=["health"])
@@ -15,21 +14,10 @@ router = APIRouter(tags=["health"])
 
 @router.get("/health", response_model=HealthResponse)
 async def health_check() -> HealthResponse:
-    """Return service health, including Mem0 connectivity."""
+    """Return basic service health without external dependencies."""
 
-    service = AsyncMemoryService()
-    try:
-        mem0_connected = True
-        try:
-            await service.get_user_app_ids("health_check")
-        except Exception:
-            mem0_connected = False
-
-        return HealthResponse(
-            status="ok",
-            service="master-mind-fastapi",
-            mem0_connected=mem0_connected,
-            timestamp=datetime.utcnow(),
-        )
-    except Exception as exc:  # pragma: no cover - defensive
-        raise HTTPException(status_code=500, detail="Health check failed") from exc
+    return HealthResponse(
+        status="healthy",
+        service="master-mind-fastapi",
+        timestamp=datetime.utcnow(),
+    )


### PR DESCRIPTION
## Summary
- remove Mem0 dependency from the FastAPI health endpoint and return a static status payload
- simplify the HealthResponse model to match the lighter payload
- update documentation to reflect the lightweight health check behavior

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d407913a4883248de037b039b284aa