### PR TITLE
Separate save and create actions in popup

### DIFF
--- a/extension/popup.html
+++ b/extension/popup.html
@@ -13,13 +13,13 @@
       <option value="development">Development</option>
     </select>
   </label>
-  <div class="form-group">
+  <div class="form-group user-section">
     <label for="userId">User ID</label>
     <input id="userId" type="text" placeholder="Enter your user ID" />
     <small>Enter your User ID first, then save to load available App IDs.</small>
-    <button id="save">Save User ID</button>
+    <button id="saveUserIdBtn" type="button">Save User ID</button>
   </div>
-  <div class="form-group">
+  <div class="form-group app-section">
     <label for="assignment-select">App ID</label>
     <select id="assignment-select" required disabled>
       <option value="">Save user ID to load app IDs</option>
@@ -30,6 +30,7 @@
     <label for="new-assignment-name">New app ID</label>
     <input id="new-assignment-name" type="text" placeholder="App ID" />
     <div id="new-assignment-feedback" class="validation-message" hidden></div>
+    <button id="createAppIdBtn" type="button">Create App ID</button>
   </div>
   <div id="connection"></div>
   <div id="status"></div>

--- a/extension/styles.css
+++ b/extension/styles.css
@@ -53,6 +53,16 @@ select {
 button {
   margin-top: 10px;
 }
+
+.user-section {
+  margin-bottom: 15px;
+  padding-bottom: 10px;
+  border-bottom: 1px solid #eee;
+}
+
+.app-section {
+  margin-top: 10px;
+}
 #status {
   margin-top: 10px;
   color: green;

--- a/extension/tests/popup.test.js
+++ b/extension/tests/popup.test.js
@@ -10,11 +10,13 @@ function setupDom() {
     </select>
     <select id="assignment-select"></select>
     <div id="assignment-loading" hidden></div>
-    <div id="new-assignment-container" hidden></div>
-    <input id="new-assignment-name" type="text" />
-    <div id="new-assignment-feedback" hidden></div>
+    <div id="new-assignment-container" hidden>
+      <input id="new-assignment-name" type="text" />
+      <div id="new-assignment-feedback" hidden></div>
+      <button id="createAppIdBtn">Create App ID</button>
+    </div>
     <input id="userId" type="text" />
-    <button id="save">Save</button>
+    <button id="saveUserIdBtn">Save User ID</button>
     <div id="connection"></div>
     <div id="status"></div>
   `;
@@ -92,7 +94,7 @@ describe('popup assignment creation flow', () => {
   test('creates a new app ID and saves the selection', async () => {
     const assignmentSelect = document.getElementById('assignment-select');
     const newAssignmentInput = document.getElementById('new-assignment-name');
-    const saveButton = document.getElementById('save');
+    const createButton = document.getElementById('createAppIdBtn');
 
     assignmentSelect.value = ADD_NEW_ASSIGNMENT_OPTION;
     assignmentSelect.dispatchEvent(new Event('change'));
@@ -100,7 +102,7 @@ describe('popup assignment creation flow', () => {
     newAssignmentInput.value = 'NewApp01';
     newAssignmentInput.dispatchEvent(new Event('input'));
 
-    saveButton.click();
+    createButton.click();
 
     await flushPromises();
     await flushPromises();


### PR DESCRIPTION
## Summary
- add dedicated Save User ID and Create App ID buttons to the extension popup markup
- refactor popup logic to manage independent button states, auto-save selected app IDs, and handle assignment creation separately
- style the new sections and update tests for the revised DOM structure and workflow

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d409e0afc8832496316c88e27f2848