### PR TITLE
Ensure assignment creation sends user id

### DIFF
--- a/extension/api.js
+++ b/extension/api.js
@@ -72,6 +72,11 @@ class APIClient {
         const { userId } = await getSettings();
         const normalizedPayload = { ...payload };
 
+        const providedUserId =
+            typeof normalizedPayload.user_id === 'string'
+                ? normalizedPayload.user_id.trim()
+                : '';
+
         if (!normalizedPayload.appid) {
             if (normalizedPayload.app_id) {
                 normalizedPayload.appid = normalizedPayload.app_id;
@@ -80,8 +85,10 @@ class APIClient {
             }
         }
 
-        if (userId) {
-            normalizedPayload.user_id = userId;
+        if (userId && userId.trim()) {
+            normalizedPayload.user_id = userId.trim();
+        } else if (providedUserId) {
+            normalizedPayload.user_id = providedUserId;
         } else {
             delete normalizedPayload.user_id;
         }
@@ -90,8 +97,10 @@ class APIClient {
         delete normalizedPayload.name;
 
         payload.appid = normalizedPayload.appid;
-        if (userId) {
-            payload.user_id = userId;
+        if (userId && userId.trim()) {
+            payload.user_id = userId.trim();
+        } else if (providedUserId) {
+            payload.user_id = providedUserId;
         } else {
             delete payload.user_id;
         }

--- a/extension/popup.js
+++ b/extension/popup.js
@@ -654,7 +654,8 @@ async function createNewApp(desiredAppId) {
 
     const createdAssignment = await runWithRetry(() =>
       apiClient.createAssignment(baseUrl, {
-        appid: desiredAppId
+        appid: desiredAppId,
+        user_id: normalized
       })
     );
 


### PR DESCRIPTION
## Summary
- keep the assignment creation request payload aware of any provided user id
- allow the popup flow to pass through the freshly entered user id when creating an app id

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d4a997d7388324a437fc05f4f8baa2