### PR TITLE
Normalize assignment app_id naming

### DIFF
--- a/backend-v2/app/models.py
+++ b/backend-v2/app/models.py
@@ -23,7 +23,7 @@ class AppIdsResponse(BaseModel):
 class AssignmentCreateRequest(BaseModel):
     """Payload for creating an assignment namespace."""
 
-    appid: str = Field(
+    app_id: str = Field(
         min_length=8,
         pattern=r"^[A-Za-z0-9]{8,}$",
         description="App ID for Mem0 (8+ alphanumeric characters)",
@@ -35,7 +35,7 @@ class AssignmentResponse(BaseModel):
     """Assignment metadata returned after creation."""
 
     id: str
-    appid: str
+    app_id: str
     user_id: str
     status: str
     created_at: datetime

--- a/backend-v2/app/routers/assignments.py
+++ b/backend-v2/app/routers/assignments.py
@@ -18,6 +18,6 @@ async def create_assignment(request: AssignmentCreateRequest) -> AssignmentRespo
     service = AsyncMemoryService()
     assignment = await service.create_assignment(
         user_id=request.user_id,
-        app_id=request.appid,
+        app_id=request.app_id,
     )
     return AssignmentResponse(**assignment)

--- a/backend-v2/app/services/memory.py
+++ b/backend-v2/app/services/memory.py
@@ -53,7 +53,7 @@ class AsyncMemoryService:
 
         return {
             "id": assignment_id,
-            "appid": app_id,
+            "app_id": app_id,
             "user_id": user_id,
             "status": "created",
             "created_at": created_at,

--- a/extension/api.js
+++ b/extension/api.js
@@ -77,12 +77,20 @@ class APIClient {
                 ? normalizedPayload.user_id.trim()
                 : '';
 
-        if (!normalizedPayload.appid) {
-            if (normalizedPayload.app_id) {
-                normalizedPayload.appid = normalizedPayload.app_id;
-            } else if (normalizedPayload.name) {
-                normalizedPayload.appid = normalizedPayload.name;
+        const derivedAppId = (() => {
+            if (typeof normalizedPayload.app_id === 'string' && normalizedPayload.app_id.trim()) {
+                return normalizedPayload.app_id.trim();
             }
+            if (typeof normalizedPayload.name === 'string' && normalizedPayload.name.trim()) {
+                return normalizedPayload.name.trim();
+            }
+            return '';
+        })();
+
+        if (derivedAppId) {
+            normalizedPayload.app_id = derivedAppId;
+        } else {
+            delete normalizedPayload.app_id;
         }
 
         if (userId && userId.trim()) {
@@ -93,10 +101,13 @@ class APIClient {
             delete normalizedPayload.user_id;
         }
 
-        delete normalizedPayload.app_id;
         delete normalizedPayload.name;
 
-        payload.appid = normalizedPayload.appid;
+        if (derivedAppId) {
+            payload.app_id = derivedAppId;
+        } else {
+            delete payload.app_id;
+        }
         if (userId && userId.trim()) {
             payload.user_id = userId.trim();
         } else if (providedUserId) {
@@ -104,7 +115,6 @@ class APIClient {
         } else {
             delete payload.user_id;
         }
-        delete payload.app_id;
         delete payload.name;
 
         return this.request('/api/v1/assignments/', {

--- a/extension/popup.js
+++ b/extension/popup.js
@@ -654,7 +654,7 @@ async function createNewApp(desiredAppId) {
 
     const createdAssignment = await runWithRetry(() =>
       apiClient.createAssignment(baseUrl, {
-        appid: desiredAppId,
+        app_id: desiredAppId,
         user_id: normalized
       })
     );

--- a/extension/tests/api.test.js
+++ b/extension/tests/api.test.js
@@ -40,7 +40,7 @@ describe('APIClient.createAssignment', () => {
   });
 
   test('injects the stored user id into the assignment payload', async () => {
-    const payload = { appid: 'ABCDEFGH', user_id: 'malicious-user' };
+    const payload = { app_id: 'ABCDEFGH', user_id: 'malicious-user' };
 
     await apiClient.createAssignment('https://custom.example', payload);
 
@@ -54,9 +54,9 @@ describe('APIClient.createAssignment', () => {
     expect(options.headers['X-App-Id']).toBe('app-xyz');
 
     const body = JSON.parse(options.body);
-    expect(body).toEqual({ appid: 'ABCDEFGH', user_id: 'user-123' });
+    expect(body).toEqual({ app_id: 'ABCDEFGH', user_id: 'user-123' });
     expect(payload.user_id).toBe('user-123');
-    expect(payload.appid).toBe('ABCDEFGH');
+    expect(payload.app_id).toBe('ABCDEFGH');
   });
 
   test('falls back to the configured base URL when none is provided', async () => {
@@ -66,13 +66,13 @@ describe('APIClient.createAssignment', () => {
       apiBaseUrl: 'https://fallback.example'
     });
 
-    await apiClient.createAssignment(undefined, { appid: 'HGFEDCBA' });
+    await apiClient.createAssignment(undefined, { app_id: 'HGFEDCBA' });
 
     expect(fetch).toHaveBeenCalledTimes(1);
     const [requestUrl, options] = fetch.mock.calls[0];
     expect(requestUrl).toBe('https://fallback.example/api/v1/assignments/');
 
     const body = JSON.parse(options.body);
-    expect(body).toEqual({ appid: 'HGFEDCBA', user_id: 'user-abc' });
+    expect(body).toEqual({ app_id: 'HGFEDCBA', user_id: 'user-abc' });
   });
 });

--- a/extension/tests/popup.test.js
+++ b/extension/tests/popup.test.js
@@ -60,8 +60,8 @@ describe('popup assignment creation flow', () => {
     mockSetSettings = jest.fn().mockResolvedValue(undefined);
     createdAppId = '';
     mockCreateAssignment = jest.fn().mockImplementation((_baseUrl, payload) => {
-      createdAppId = payload.appid;
-      return Promise.resolve({ id: 10, name: 'NewApp01', app_id: payload.appid });
+      createdAppId = payload.app_id;
+      return Promise.resolve({ id: 10, name: 'NewApp01', app_id: payload.app_id });
     });
     mockFetchUserAppIds = jest
       .fn()
@@ -114,7 +114,7 @@ describe('popup assignment creation flow', () => {
 
     expect(mockCreateAssignment).toHaveBeenCalledTimes(1);
     const [, createPayload] = mockCreateAssignment.mock.calls[0];
-    expect(createPayload).toEqual({ appid: 'NewApp01' });
+    expect(createPayload).toEqual({ app_id: 'NewApp01', user_id: 'user-123' });
 
     expect(mockFetchUserAppIds).toHaveBeenCalledTimes(2);
     expect(mockFetchUserAppIds).toHaveBeenLastCalledWith('https://api.example', 'user-123');


### PR DESCRIPTION
## Summary
- align FastAPI assignment request/response models to expose `app_id`
- update memory service and extension client flows to read and send `app_id`
- refresh extension tests to validate the new field name

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d4b4f9905c8324a69a2964b4d5f081