### PR TITLE
Simplify popup flow for user and app setup

### DIFF
--- a/extension/api.js
+++ b/extension/api.js
@@ -68,58 +68,20 @@ class APIClient {
         return this.request(`/api/v1/users/${encodedUserId}/app-ids`, { baseUrl });
     }
 
-    async createAssignment(baseUrl, payload = {}) {
-        const { userId } = await getSettings();
-        const normalizedPayload = { ...payload };
+    async createAssignment(baseUrl, { userId, appId } = {}) {
+        const payload = {};
 
-        const providedUserId =
-            typeof normalizedPayload.user_id === 'string'
-                ? normalizedPayload.user_id.trim()
-                : '';
-
-        const derivedAppId = (() => {
-            if (typeof normalizedPayload.app_id === 'string' && normalizedPayload.app_id.trim()) {
-                return normalizedPayload.app_id.trim();
-            }
-            if (typeof normalizedPayload.name === 'string' && normalizedPayload.name.trim()) {
-                return normalizedPayload.name.trim();
-            }
-            return '';
-        })();
-
-        if (derivedAppId) {
-            normalizedPayload.app_id = derivedAppId;
-        } else {
-            delete normalizedPayload.app_id;
-        }
-
-        if (userId && userId.trim()) {
-            normalizedPayload.user_id = userId.trim();
-        } else if (providedUserId) {
-            normalizedPayload.user_id = providedUserId;
-        } else {
-            delete normalizedPayload.user_id;
-        }
-
-        delete normalizedPayload.name;
-
-        if (derivedAppId) {
-            payload.app_id = derivedAppId;
-        } else {
-            delete payload.app_id;
-        }
-        if (userId && userId.trim()) {
+        if (typeof userId === 'string' && userId.trim()) {
             payload.user_id = userId.trim();
-        } else if (providedUserId) {
-            payload.user_id = providedUserId;
-        } else {
-            delete payload.user_id;
         }
-        delete payload.name;
+
+        if (typeof appId === 'string' && appId.trim()) {
+            payload.app_id = appId.trim();
+        }
 
         return this.request('/api/v1/assignments/', {
             method: 'POST',
-            body: JSON.stringify(normalizedPayload),
+            body: JSON.stringify(payload),
             baseUrl
         });
     }

--- a/extension/popup.js
+++ b/extension/popup.js
@@ -12,7 +12,6 @@ const submitBtn = document.getElementById('submit');
 const newAssignmentContainer = document.getElementById('new-assignment-container');
 const newAssignmentInput = document.getElementById('new-assignment-name');
 const newAssignmentFeedback = document.getElementById('new-assignment-feedback');
-const interactionGuardEl = document.getElementById('interaction-guard');
 const globalErrorAnnouncer = document.getElementById('global-error-announcer');
 
 const userIdSavedIcon = document.getElementById('userId-saved');
@@ -21,93 +20,17 @@ const appIdSavedIcon = document.getElementById('appId-saved');
 const appIdEditIcon = document.getElementById('appId-edit');
 
 const ADD_NEW_ASSIGNMENT_OPTION = '__add_new_assignment__';
-const USER_ID_PROMPT_MESSAGE = 'Enter your User ID first, then save to load available App IDs.';
 const APP_ID_PATTERN = /^[A-Za-z0-9]{8,}$/;
 const USER_ID_PATTERN = /^[A-Za-z0-9._-]{4,}$/;
 
-const formState = {
-  busy: false,
-  busyReason: '',
-  error: '',
-  fields: {
-    userId: { saved: false, editing: true },
-    appId: { saved: false, editing: false }
-  }
+const state = {
+  userIdLocked: false,
+  appIdSaved: false,
+  setupComplete: false
 };
 
-const busyOperations = new Set();
-const fieldElements = {
-  userId: userIdEl,
-  appId: assignmentEl
-};
-const savedIcons = {
-  userId: userIdSavedIcon,
-  appId: appIdSavedIcon
-};
-const editIcons = {
-  userId: userIdEditIcon,
-  appId: appIdEditIcon
-};
-
-let statusTimeoutId = null;
-let lastLoadedUserId = '';
 let isSubmitting = false;
-let loadRequestToken = 0;
-let scheduledLoadTimer = null;
-
-function wait(delay) {
-  return new Promise(resolve => setTimeout(resolve, delay));
-}
-
-async function runWithRetry(fn, { retries = 2, baseDelay = 200 } = {}) {
-  let attempt = 0;
-  let lastError;
-  while (attempt <= retries) {
-    try {
-      return await fn();
-    } catch (error) {
-      lastError = error;
-      if (attempt === retries) {
-        break;
-      }
-      await wait(baseDelay * (attempt + 1));
-      attempt += 1;
-    }
-  }
-  throw lastError;
-}
-
-function updateBusyState() {
-  const isBusy = busyOperations.size > 0;
-  const activeReason = isBusy ? Array.from(busyOperations).at(-1) ?? '' : '';
-
-  if (formState.busy === isBusy && formState.busyReason === activeReason) {
-    return;
-  }
-
-  formState.busy = isBusy;
-  formState.busyReason = activeReason;
-
-  popupRootEl?.setAttribute('aria-busy', isBusy ? 'true' : 'false');
-
-  if (interactionGuardEl) {
-    const shouldHide = !isBusy;
-    if (interactionGuardEl.hidden !== shouldHide) {
-      interactionGuardEl.hidden = shouldHide;
-    }
-    interactionGuardEl.setAttribute('aria-hidden', shouldHide ? 'true' : 'false');
-  }
-}
-
-function beginBusy(key) {
-  busyOperations.add(key);
-  updateBusyState();
-}
-
-function endBusy(key) {
-  busyOperations.delete(key);
-  updateBusyState();
-}
+let statusTimeoutId = null;
 
 function clearStatusTimer() {
   if (statusTimeoutId) {
@@ -122,11 +45,11 @@ function setStatus(message, isError = false, { persist = false } = {}) {
   }
 
   statusEl.textContent = message;
-  statusEl.style.color = isError ? '#d93025' : '#198754';
   statusEl.hidden = !message;
   statusEl.dataset.statusType = isError ? 'error' : message ? 'success' : '';
   statusEl.setAttribute('role', isError ? 'alert' : 'status');
   statusEl.setAttribute('aria-live', isError ? 'assertive' : 'polite');
+  statusEl.style.color = isError ? '#d93025' : '#198754';
 
   if (globalErrorAnnouncer) {
     globalErrorAnnouncer.textContent = isError ? message : '';
@@ -147,148 +70,11 @@ function setStatus(message, isError = false, { persist = false } = {}) {
 }
 
 function setError(message) {
-  formState.error = message;
   if (message) {
     setStatus(message, true, { persist: true });
   } else if (statusEl?.dataset?.statusType === 'error') {
     setStatus('');
   }
-}
-
-function setFieldState(fieldName, updates) {
-  if (!formState.fields[fieldName]) {
-    return;
-  }
-  formState.fields[fieldName] = {
-    ...formState.fields[fieldName],
-    ...updates
-  };
-}
-
-function lockField(fieldName, { saved = false } = {}) {
-  const field = fieldElements[fieldName];
-  if (!field) {
-    return;
-  }
-
-  setFieldState(fieldName, { saved, editing: false });
-
-  if (fieldName === 'userId') {
-    field.readOnly = true;
-  }
-  field.disabled = true;
-
-  const savedIcon = savedIcons[fieldName];
-  const editIcon = editIcons[fieldName];
-
-  if (savedIcon) {
-    savedIcon.hidden = !saved;
-  }
-  if (editIcon) {
-    editIcon.hidden = false;
-  }
-
-  updateSubmitButton();
-}
-
-function unlockField(fieldName) {
-  const field = fieldElements[fieldName];
-  if (!field) {
-    return;
-  }
-
-  setFieldState(fieldName, { saved: false, editing: true });
-
-  if (fieldName === 'userId') {
-    field.readOnly = false;
-  }
-  field.disabled = false;
-
-  const savedIcon = savedIcons[fieldName];
-  const editIcon = editIcons[fieldName];
-
-  if (savedIcon) {
-    savedIcon.hidden = true;
-  }
-  if (editIcon) {
-    editIcon.hidden = true;
-  }
-
-  if (fieldName === 'userId') {
-    field.focus();
-    field.select();
-  } else if (fieldName === 'appId') {
-    field.focus();
-  }
-
-  updateSubmitButton();
-}
-
-function resetAssignmentDropdown(message) {
-  if (!assignmentEl) {
-    return;
-  }
-  assignmentEl.innerHTML = '';
-  const option = document.createElement('option');
-  option.value = '';
-  option.textContent = message;
-  assignmentEl.appendChild(option);
-  assignmentEl.value = '';
-}
-
-function setAssignmentPlaceholder(message) {
-  resetAssignmentDropdown(message);
-}
-
-function toggleAssignmentLoading(isLoading) {
-  if (assignmentLoadingEl) {
-    assignmentLoadingEl.hidden = !isLoading;
-  }
-  assignmentEl?.classList.toggle('loading', isLoading);
-  assignmentEl?.setAttribute('aria-busy', isLoading ? 'true' : 'false');
-}
-
-function hideNewAssignmentInput() {
-  if (newAssignmentContainer) {
-    newAssignmentContainer.hidden = true;
-  }
-  if (newAssignmentInput) {
-    newAssignmentInput.value = '';
-    newAssignmentInput.setAttribute('aria-invalid', 'false');
-  }
-  setAssignmentNameFeedback('');
-}
-
-function resetAppField() {
-  hideNewAssignmentInput();
-  toggleAssignmentLoading(false);
-  setFieldState('appId', { saved: false, editing: false });
-  resetAssignmentDropdown('Save User ID first');
-  if (assignmentEl) {
-    assignmentEl.disabled = true;
-  }
-  if (appIdSavedIcon) {
-    appIdSavedIcon.hidden = true;
-  }
-  if (appIdEditIcon) {
-    appIdEditIcon.hidden = true;
-  }
-  updateSubmitButton();
-}
-
-function ensureAppFieldEditable() {
-  if (!assignmentEl) {
-    return;
-  }
-  assignmentEl.disabled = false;
-  setFieldState('appId', { editing: true });
-  if (appIdSavedIcon) {
-    appIdSavedIcon.hidden = true;
-  }
-  if (appIdEditIcon) {
-    appIdEditIcon.hidden = true;
-  }
-  updateSubmitButton();
 }
 
 function validateAssignmentName(name) {
@@ -333,19 +119,225 @@ function validateUserId(value) {
 }
 
 function setAssignmentNameFeedback(message = '') {
-  if (!newAssignmentFeedback) {
+  if (!newAssignmentFeedback || !newAssignmentInput) {
     return;
   }
 
   if (message) {
     newAssignmentFeedback.textContent = message;
     newAssignmentFeedback.hidden = false;
-    newAssignmentInput?.setAttribute('aria-invalid', 'true');
+    newAssignmentInput.setAttribute('aria-invalid', 'true');
   } else {
     newAssignmentFeedback.textContent = '';
     newAssignmentFeedback.hidden = true;
-    newAssignmentInput?.setAttribute('aria-invalid', 'false');
+    newAssignmentInput.setAttribute('aria-invalid', 'false');
   }
+}
+
+function resetAssignmentDropdown(message) {
+  if (!assignmentEl) {
+    return;
+  }
+  assignmentEl.innerHTML = '';
+  const option = document.createElement('option');
+  option.value = '';
+  option.textContent = message;
+  assignmentEl.appendChild(option);
+  assignmentEl.value = '';
+}
+
+function hideNewAssignmentInput() {
+  if (newAssignmentContainer) {
+    newAssignmentContainer.hidden = true;
+  }
+  if (newAssignmentInput) {
+    newAssignmentInput.value = '';
+  }
+  setAssignmentNameFeedback('');
+}
+
+function showNewAssignmentInput() {
+  if (!newAssignmentContainer || !newAssignmentInput) {
+    return;
+  }
+  newAssignmentContainer.hidden = false;
+  newAssignmentInput.focus();
+  handleNewAssignmentInput();
+}
+
+function updateUserIdIcons() {
+  if (userIdSavedIcon) {
+    const showCheckmark = !state.userIdLocked;
+    userIdSavedIcon.hidden = !showCheckmark;
+    userIdSavedIcon.setAttribute('aria-hidden', showCheckmark ? 'false' : 'true');
+    userIdSavedIcon.setAttribute('aria-label', 'Save user ID');
+  }
+  if (userIdEditIcon) {
+    userIdEditIcon.hidden = !state.userIdLocked;
+    userIdEditIcon.setAttribute('aria-hidden', state.userIdLocked ? 'false' : 'true');
+  }
+}
+
+function updateAppIdIcons() {
+  if (appIdSavedIcon) {
+    appIdSavedIcon.hidden = !state.appIdSaved;
+    appIdSavedIcon.setAttribute('aria-hidden', state.appIdSaved ? 'false' : 'true');
+  }
+  if (appIdEditIcon) {
+    appIdEditIcon.hidden = !state.appIdSaved;
+    appIdEditIcon.setAttribute('aria-hidden', state.appIdSaved ? 'false' : 'true');
+  }
+}
+
+function clearAppSelections() {
+  hideNewAssignmentInput();
+  resetAssignmentDropdown(state.userIdLocked ? 'Choose app ID...' : 'Save User ID first');
+  assignmentEl.disabled = !state.userIdLocked;
+  state.appIdSaved = false;
+  updateAppIdIcons();
+}
+
+function toggleAssignmentLoading(isLoading) {
+  if (assignmentLoadingEl) {
+    assignmentLoadingEl.hidden = !isLoading;
+  }
+  if (assignmentEl) {
+    assignmentEl.classList.toggle('loading', isLoading);
+    assignmentEl.setAttribute('aria-busy', isLoading ? 'true' : 'false');
+  }
+}
+
+function populateAssignmentOptions(appIds = [], preferredAppId = '') {
+  resetAssignmentDropdown(appIds.length ? 'Choose app ID...' : 'No app IDs found. Add a new one.');
+
+  appIds.forEach(appId => {
+    const option = document.createElement('option');
+    option.value = appId;
+    option.textContent = appId;
+    assignmentEl.appendChild(option);
+  });
+
+  const addOption = document.createElement('option');
+  addOption.value = ADD_NEW_ASSIGNMENT_OPTION;
+  addOption.textContent = 'Add New App ID';
+  assignmentEl.appendChild(addOption);
+
+  assignmentEl.disabled = false;
+
+  if (preferredAppId && appIds.includes(preferredAppId)) {
+    assignmentEl.value = preferredAppId;
+  }
+}
+
+function ensureOptionExists(appId) {
+  if (!assignmentEl) {
+    return;
+  }
+  const existing = Array.from(assignmentEl.options).find(option => option.value === appId);
+  if (existing) {
+    return;
+  }
+  const option = document.createElement('option');
+  option.value = appId;
+  option.textContent = appId;
+  const addOption = Array.from(assignmentEl.options).find(option => option.value === ADD_NEW_ASSIGNMENT_OPTION);
+  if (addOption) {
+    assignmentEl.insertBefore(option, addOption);
+  } else {
+    assignmentEl.appendChild(option);
+  }
+}
+
+function lockUserId(normalizedUserId) {
+  state.userIdLocked = true;
+  state.setupComplete = false;
+  userIdEl.value = normalizedUserId;
+  userIdEl.readOnly = true;
+  userIdEl.setAttribute('aria-readonly', 'true');
+  updateUserIdIcons();
+  clearAppSelections();
+  loadAppIds(normalizedUserId);
+}
+
+function unlockUserId() {
+  const confirmed = window.confirm('Editing your User ID will clear the selected App ID. Continue?');
+  if (!confirmed) {
+    return;
+  }
+  state.userIdLocked = false;
+  state.setupComplete = false;
+  state.appIdSaved = false;
+  userIdEl.readOnly = false;
+  userIdEl.setAttribute('aria-readonly', 'false');
+  userIdEl.focus();
+  userIdEl.select();
+  updateUserIdIcons();
+  clearAppSelections();
+  setError('');
+  setStatus('User ID unlocked. Save to load App IDs.', false, { persist: true });
+  updateSubmitButton();
+}
+
+function lockAppSelection(appId) {
+  assignmentEl.value = appId;
+  assignmentEl.disabled = true;
+  state.appIdSaved = true;
+  updateAppIdIcons();
+  hideNewAssignmentInput();
+}
+
+function unlockAppSelection() {
+  assignmentEl.disabled = false;
+  state.appIdSaved = false;
+  state.setupComplete = false;
+  updateAppIdIcons();
+  updateSubmitButton();
+  setStatus('Select an App ID to continue.', false, { persist: true });
+}
+
+function getAppSelectionState() {
+  if (!state.userIdLocked) {
+    return { ready: false, appId: '', isNew: false };
+  }
+
+  const selectedValue = assignmentEl.value;
+  if (!selectedValue) {
+    return { ready: false, appId: '', isNew: false };
+  }
+
+  if (selectedValue === ADD_NEW_ASSIGNMENT_OPTION) {
+    const { valid, normalizedName } = validateAssignmentName(newAssignmentInput?.value ?? '');
+    return { ready: valid, appId: normalizedName, isNew: true };
+  }
+
+  return { ready: true, appId: selectedValue, isNew: false };
+}
+
+function updateSubmitButton() {
+  if (!submitBtn) {
+    return;
+  }
+
+  if (isSubmitting) {
+    submitBtn.textContent = 'Saving...';
+    submitBtn.disabled = true;
+    submitBtn.classList.remove('saved');
+    return;
+  }
+
+  if (state.setupComplete) {
+    submitBtn.textContent = 'Setup Complete';
+    submitBtn.disabled = true;
+    submitBtn.classList.add('saved');
+    return;
+  }
+
+  submitBtn.textContent = 'Submit';
+  submitBtn.classList.remove('saved');
+
+  const selection = getAppSelectionState();
+  const ready = state.userIdLocked && selection.ready;
+  submitBtn.disabled = !ready;
 }
 
 function extractErrorMessage(error) {
@@ -399,85 +391,19 @@ function getFriendlyErrorMessage(error, fallback) {
   return fallback;
 }
 
-function updateSubmitButton() {
-  if (!submitBtn) {
+async function loadAppIds(userId, preferredAppId = '') {
+  if (!userId) {
+    clearAppSelections();
     return;
   }
 
-  if (isSubmitting) {
-    submitBtn.textContent = 'Saving...';
-    submitBtn.disabled = true;
-    submitBtn.classList.remove('saved');
-    return;
-  }
-
-  const userIdValue = userIdEl.value.trim();
-  const selectedAssignment = assignmentEl.value;
-  const isAddingNewAssignment = selectedAssignment === ADD_NEW_ASSIGNMENT_OPTION;
-  const { valid: newAssignmentValid } = validateAssignmentName(newAssignmentInput?.value ?? '');
-
-  const allSaved = formState.fields.userId.saved && formState.fields.appId.saved;
-
-  if (allSaved) {
-    submitBtn.textContent = 'Saved ✅';
-    submitBtn.disabled = true;
-    submitBtn.classList.add('saved');
-    return;
-  }
-
-  submitBtn.classList.remove('saved');
-
-  const hasAppSelection = Boolean(selectedAssignment) && selectedAssignment !== ADD_NEW_ASSIGNMENT_OPTION;
-  const needsUserIdSave = !formState.fields.userId.saved;
-  const needsAppIdSave =
-    !formState.fields.appId.saved &&
-    (selectedAssignment === ADD_NEW_ASSIGNMENT_OPTION || hasAppSelection || (!assignmentEl.disabled && assignmentEl.options.length > 0));
-
-  const hasWorkToDo = needsUserIdSave || needsAppIdSave;
-
-  const userReady = !needsUserIdSave || Boolean(userIdValue);
-  let appReady = true;
-  if (needsAppIdSave) {
-    appReady = isAddingNewAssignment ? newAssignmentValid : hasAppSelection;
-  }
-
-  submitBtn.textContent = hasWorkToDo ? 'Submit' : 'Complete Setup';
-  submitBtn.disabled = !(hasWorkToDo && userReady && appReady);
-}
-
-async function loadAppIds(selectedAppId = '', { userIdOverride, silent = false } = {}) {
-  const environment = envEl.value;
-  const baseUrl = ENVIRONMENTS[environment] || ENVIRONMENTS.production;
-  const activeUserId = (userIdOverride ?? userIdEl.value ?? '').trim();
-  const requestToken = ++loadRequestToken;
-  const busyKey = `load-apps-${requestToken}`;
-
-  hideNewAssignmentInput();
-  setFieldState('appId', { saved: false });
-
-  if (!activeUserId) {
-    resetAppField();
-    if (!silent) {
-      setStatus(USER_ID_PROMPT_MESSAGE, false, { persist: true });
-    }
-    updateSubmitButton();
-    return [];
-  }
-
-  beginBusy(busyKey);
   toggleAssignmentLoading(true);
   assignmentEl.disabled = true;
-  setFieldState('appId', { editing: false });
-  updateSubmitButton();
-
-  let loaded = false;
 
   try {
-    const response = await runWithRetry(() => apiClient.fetchUserAppIds(baseUrl, activeUserId));
-    if (requestToken !== loadRequestToken) {
-      return [];
-    }
-
+    const environment = envEl.value;
+    const baseUrl = ENVIRONMENTS[environment] || ENVIRONMENTS.production;
+    const response = await apiClient.fetchUserAppIds(baseUrl, userId);
     const rawAppIds = Array.isArray(response)
       ? response
       : Array.isArray(response?.app_ids)
@@ -485,373 +411,107 @@ async function loadAppIds(selectedAppId = '', { userIdOverride, silent = false }
         : [];
 
     const seen = new Set();
-    const appIds = [];
-    rawAppIds.forEach(item => {
-      if (typeof item !== 'string') {
-        return;
-      }
-      const trimmed = item.trim();
-      if (!trimmed || seen.has(trimmed)) {
-        return;
-      }
-      seen.add(trimmed);
-      appIds.push(trimmed);
-    });
+    const appIds = rawAppIds
+      .filter(item => typeof item === 'string')
+      .map(item => item.trim())
+      .filter(item => item.length >= 8 && !seen.has(item) && (seen.add(item) || true));
 
-    assignmentEl.innerHTML = '';
-
-    if (appIds.length) {
-      const placeholderOption = document.createElement('option');
-      placeholderOption.value = '';
-      placeholderOption.textContent = 'Choose app ID...';
-      assignmentEl.appendChild(placeholderOption);
-    } else {
-      setAssignmentPlaceholder('No app IDs found. Create a new one to get started.');
-    }
-
-    appIds.forEach(appId => {
-      const option = document.createElement('option');
-      option.value = appId;
-      option.textContent = appId;
-      assignmentEl.appendChild(option);
-    });
-
-    const addOption = document.createElement('option');
-    addOption.value = ADD_NEW_ASSIGNMENT_OPTION;
-    addOption.textContent = 'Add New App ID';
-    assignmentEl.appendChild(addOption);
-
-    if (selectedAppId) {
-      const normalized = String(selectedAppId);
-      if (appIds.includes(normalized)) {
-        assignmentEl.value = normalized;
-      } else {
-        assignmentEl.value = '';
-        if (!silent) {
-          setStatus('Saved app ID is unavailable. Please choose another app ID.', true, {
-            persist: true
-          });
-        }
-      }
-    } else {
-      assignmentEl.value = '';
-    }
-
-    loaded = true;
-    lastLoadedUserId = activeUserId;
-
-    if (!silent) {
-      setStatus(`Loaded ${appIds.length} app ID${appIds.length === 1 ? '' : 's'}`);
-    }
-
-    ensureAppFieldEditable();
+    populateAssignmentOptions(appIds, preferredAppId);
     setError('');
-    return appIds;
+    setStatus(appIds.length ? 'App IDs loaded. Select one to continue.' : 'No App IDs found. Create a new one to continue.');
   } catch (error) {
     console.error('Failed to load app IDs', error);
-    setAssignmentPlaceholder('Choose app ID...');
-    const message = getFriendlyErrorMessage(error, 'Unable to load app IDs. Please try again.');
-    if (!silent) {
-      setError(message);
-    }
-    return [];
+    const message = getFriendlyErrorMessage(error, 'Unable to load App IDs. Please try again.');
+    setError(message);
+    clearAppSelections();
   } finally {
     toggleAssignmentLoading(false);
-    assignmentEl.disabled = !loaded;
-    if (!loaded) {
-      setFieldState('appId', { editing: false });
-    } else {
-      setFieldState('appId', { editing: true });
-    }
-    updateSubmitButton();
-    endBusy(busyKey);
   }
+
+  updateSubmitButton();
 }
 
-function scheduleAppIdLoad(selectedAppId = '', options = {}) {
-  if (scheduledLoadTimer) {
-    clearTimeout(scheduledLoadTimer);
-  }
-  scheduledLoadTimer = setTimeout(() => {
-    loadAppIds(selectedAppId, options);
-    scheduledLoadTimer = null;
-  }, 250);
-}
-
-async function saveUserId(userId, { appIdForSettings = '' } = {}) {
-  const environment = envEl.value;
-  const busyKey = 'save-user';
-
-  beginBusy(busyKey);
-
-  try {
-    await runWithRetry(() => setSettings({ environment, userId, appId: appIdForSettings }));
-    lockField('userId', { saved: true });
-    const shouldReload = lastLoadedUserId !== userId;
-    lastLoadedUserId = userId;
-    if (shouldReload) {
-      await loadAppIds(appIdForSettings, { userIdOverride: userId, silent: true });
-    }
-    const successMessage = appIdForSettings ? 'Settings saved.' : 'User ID saved.';
-    setStatus(successMessage);
-    setError('');
-    updateConnection();
-  } catch (error) {
-    console.error('Failed to save settings', error);
-    const errorMessage = getFriendlyErrorMessage(error, 'Failed to save settings. Please try again.');
-    unlockField('userId');
-    setError(errorMessage);
-    throw error;
-  } finally {
-    endBusy(busyKey);
-  }
-}
-
-async function saveAppSelection(appId) {
-  const { valid, message, normalized } = validateUserId(userIdEl.value);
-  if (!valid) {
-    setError(message);
+async function handleSubmit() {
+  if (!submitBtn || submitBtn.disabled || isSubmitting) {
     return;
   }
 
-  const environment = envEl.value;
-  const busyKey = 'save-app';
-
-  beginBusy(busyKey);
-
-  try {
-    assignmentEl.value = appId;
-    await runWithRetry(() => setSettings({ environment, userId: normalized, appId }));
-    lockField('appId', { saved: true });
-    setStatus('App ID saved.');
-    setError('');
-  } catch (error) {
-    console.error('Failed to save app ID', error);
-    const message = getFriendlyErrorMessage(error, 'Failed to save app ID. Please try again.');
-    setError(message);
-    throw error;
-  } finally {
-    endBusy(busyKey);
-  }
-}
-
-async function createNewApp(desiredAppId) {
-  const { valid, message, normalized } = validateUserId(userIdEl.value);
+  const { valid, message, normalized: normalizedUserId } = validateUserId(userIdEl.value);
   if (!valid) {
     setError(message);
-    return '';
+    updateSubmitButton();
+    return;
   }
+
+  const selection = getAppSelectionState();
+  if (!selection.ready) {
+    updateSubmitButton();
+    return;
+  }
+
+  isSubmitting = true;
+  setError('');
+  updateSubmitButton();
 
   const environment = envEl.value;
   const baseUrl = ENVIRONMENTS[environment] || ENVIRONMENTS.production;
-  const busyKey = 'create-app';
-
-  beginBusy(busyKey);
+  let appIdToSave = selection.appId;
 
   try {
-    setAssignmentNameFeedback('');
-    setStatus('Creating app ID...', false, { persist: true });
-
-    const createdAssignment = await runWithRetry(() =>
-      apiClient.createAssignment(baseUrl, {
-        app_id: desiredAppId,
-        user_id: normalized
-      })
-    );
-
-    const createdAssignmentId = createdAssignment?.id ? String(createdAssignment.id) : '';
-    const createdAssignmentAppId = APP_ID_PATTERN.test(createdAssignment?.app_id ?? '')
-      ? createdAssignment.app_id
-      : desiredAppId;
-    const createdAssignmentName = createdAssignment?.name ?? desiredAppId;
-
-    hideNewAssignmentInput();
-
-    const preferredSelection = createdAssignmentAppId || createdAssignmentId;
-    await loadAppIds(preferredSelection, { userIdOverride: normalized });
-
-    const optionValues = Array.from(assignmentEl.options)
-      .map(option => option.value)
-      .filter(value => value && value !== ADD_NEW_ASSIGNMENT_OPTION);
-
-    let appIdToSave =
-      createdAssignmentAppId && optionValues.includes(createdAssignmentAppId)
-        ? createdAssignmentAppId
-        : '';
-
-    if (!appIdToSave && preferredSelection && optionValues.includes(preferredSelection)) {
-      appIdToSave = preferredSelection;
-    }
-
-    if (!appIdToSave) {
-      const fallbackName = createdAssignmentName;
-      if (fallbackName && optionValues.includes(fallbackName)) {
-        appIdToSave = fallbackName;
+    if (selection.isNew) {
+      const { normalizedName, message: validationMessage, valid } = validateAssignmentName(newAssignmentInput?.value ?? '');
+      if (!valid) {
+        setAssignmentNameFeedback(validationMessage);
+        throw new Error(validationMessage);
       }
+
+      appIdToSave = normalizedName;
+      await apiClient.createAssignment(baseUrl, { userId: normalizedUserId, appId: appIdToSave });
+      ensureOptionExists(appIdToSave);
+      setStatus('App ID created.');
     }
 
-    if (!appIdToSave) {
-      setError('App ID created but could not be auto-selected. Please choose it manually.');
-      ensureAppFieldEditable();
-      return '';
-    }
+    await setSettings({ environment, userId: normalizedUserId, appId: appIdToSave });
 
-    assignmentEl.value = String(appIdToSave);
-    setStatus('App ID created. Save to confirm.');
-    setError('');
-    return String(appIdToSave);
+    lockAppSelection(appIdToSave);
+    state.setupComplete = true;
+    setStatus('Setup complete.', false, { persist: true });
   } catch (error) {
-    console.error('Failed to create app ID', error);
-    const message = getFriendlyErrorMessage(error, 'Unable to create app ID. Please try again.');
+    console.error('Failed to save configuration', error);
+    const message = getFriendlyErrorMessage(error, 'Unable to save configuration. Please try again.');
     setError(message);
-    throw error;
   } finally {
-    endBusy(busyKey);
+    isSubmitting = false;
+    updateSubmitButton();
   }
 }
 
-async function updateConnection() {
-  if (!connectionEl) {
-    return;
-  }
-  connectionEl.textContent = 'Checking...';
-  chrome.runtime.sendMessage({ type: 'health-check' }, res => {
-    const ok = res?.ok;
-    connectionEl.textContent = ok ? 'Connected' : 'Disconnected';
-    connectionEl.style.color = ok ? '#198754' : '#d93025';
-  });
-}
-
-async function init() {
-  const { environment, userId, appId } = await getSettings();
-
-  envEl.value = environment;
-  userIdEl.value = userId;
-
-  if (userId) {
-    lockField('userId', { saved: true });
-    const loadedAppIds = await loadAppIds(appId, { silent: true, userIdOverride: userId });
-
-    if (appId) {
-      const hasAppId = loadedAppIds.includes(appId);
-      if (hasAppId) {
-        assignmentEl.value = appId;
-        lockField('appId', { saved: true });
-      } else if (loadedAppIds.length) {
-        ensureAppFieldEditable();
-        setError('Saved app ID is unavailable. Please choose another app ID.');
-      }
-    }
-  } else {
-    unlockField('userId');
-    resetAppField();
-    setStatus('Enter your User ID to load saved app IDs.', false, { persist: true });
-  }
-
-  updateConnection();
-  updateSubmitButton();
-}
-
-init();
-
-envEl.addEventListener('change', () => {
-  hideNewAssignmentInput();
-  const activeUserId = userIdEl.value.trim();
-
-  setFieldState('appId', { saved: false });
-
-  if (activeUserId && formState.fields.userId.saved) {
-    scheduleAppIdLoad(formState.fields.appId.saved ? assignmentEl.value : '', {
-      userIdOverride: activeUserId,
-      silent: true
-    });
-  } else {
-    resetAppField();
-    setStatus(USER_ID_PROMPT_MESSAGE, false, { persist: true });
-  }
-
-  updateSubmitButton();
-});
-
-userIdEl.addEventListener('input', () => {
-  setFieldState('userId', { saved: false, editing: true });
-  if (userIdSavedIcon) {
-    userIdSavedIcon.hidden = true;
-  }
-  if (userIdEditIcon) {
-    userIdEditIcon.hidden = true;
-  }
-  resetAppField();
-  lastLoadedUserId = '';
+function handleAssignmentChange() {
   setError('');
-  updateSubmitButton();
-});
+  state.appIdSaved = false;
+  state.setupComplete = false;
+  updateAppIdIcons();
 
-userIdEl.addEventListener('blur', async () => {
-  const value = userIdEl.value.trim();
-  if (!value) {
-    resetAppField();
+  if (assignmentEl.value === ADD_NEW_ASSIGNMENT_OPTION) {
+    showNewAssignmentInput();
+  } else {
+    hideNewAssignmentInput();
+  }
+
+  updateSubmitButton();
+}
+
+function handleNewAssignmentInput() {
+  if (!newAssignmentInput || assignmentEl.value !== ADD_NEW_ASSIGNMENT_OPTION) {
+    setAssignmentNameFeedback('');
     updateSubmitButton();
     return;
   }
 
-  const { valid, message, normalized } = validateUserId(value);
-  if (!valid) {
-    setError(message);
-    ensureAppFieldEditable();
-    return;
-  }
-
-  lockField('userId', { saved: formState.fields.userId.saved });
-
-  if (normalized !== lastLoadedUserId) {
-    await loadAppIds(formState.fields.appId.saved ? assignmentEl.value : '', {
-      userIdOverride: normalized
-    });
-  }
-});
-
-assignmentEl.addEventListener('change', () => {
-  const selectedValue = assignmentEl.value;
-  const isAddingNewAssignment = selectedValue === ADD_NEW_ASSIGNMENT_OPTION;
-
-  setFieldState('appId', { saved: false });
-
-  if (isAddingNewAssignment) {
-    ensureAppFieldEditable();
-    if (newAssignmentContainer) {
-      newAssignmentContainer.hidden = false;
-    }
-    if (newAssignmentInput) {
-      newAssignmentInput.focus();
-    }
-  } else {
-    hideNewAssignmentInput();
-
-    if (selectedValue) {
-      lockField('appId', { saved: false });
-    } else {
-      ensureAppFieldEditable();
-    }
-  }
-
-  if (statusEl?.dataset?.statusType === 'error' && statusEl.textContent) {
-    setStatus('');
-  }
-
+  const { valid, message } = validateAssignmentName(newAssignmentInput.value ?? '');
+  setAssignmentNameFeedback(valid ? '' : message);
   updateSubmitButton();
-});
-
-newAssignmentInput?.addEventListener('input', () => {
-  if (assignmentEl.value === ADD_NEW_ASSIGNMENT_OPTION) {
-    const { message } = validateAssignmentName(newAssignmentInput.value ?? '');
-    setAssignmentNameFeedback(message);
-  } else {
-    setAssignmentNameFeedback('');
-  }
-
-  updateSubmitButton();
-});
+}
 
 function handleIconActivation(handler) {
   return event => {
@@ -866,104 +526,147 @@ function handleIconActivation(handler) {
   };
 }
 
-if (userIdEditIcon) {
-  const handleUserEdit = () => {
-    const confirmed = window.confirm(
-      'Editing your User ID will clear the current app selection until it is saved again. Continue?'
-    );
-    if (!confirmed) {
-      return;
-    }
-    unlockField('userId');
-    resetAppField();
-    setError('');
-  };
-
-  userIdEditIcon.setAttribute('role', 'button');
-  userIdEditIcon.setAttribute('tabindex', '0');
-  userIdEditIcon.addEventListener('click', handleIconActivation(handleUserEdit));
-  userIdEditIcon.addEventListener('keydown', handleIconActivation(handleUserEdit));
-}
-
-if (appIdEditIcon) {
-  const handleAppEdit = () => {
-    if (assignmentEl.options.length === 0) {
-      return;
-    }
-    const confirmed = window.confirm(
-      'Editing the App ID will require selecting or creating a new app before saving. Continue?'
-    );
-    if (!confirmed) {
-      return;
-    }
-    unlockField('appId');
-    hideNewAssignmentInput();
-    updateSubmitButton();
-  };
-
-  appIdEditIcon.setAttribute('role', 'button');
-  appIdEditIcon.setAttribute('tabindex', '0');
-  appIdEditIcon.addEventListener('click', handleIconActivation(handleAppEdit));
-  appIdEditIcon.addEventListener('keydown', handleIconActivation(handleAppEdit));
-}
-
-submitBtn.addEventListener('click', async () => {
-  if (submitBtn.disabled || isSubmitting) {
+function updateConnection() {
+  if (!connectionEl) {
     return;
   }
+  connectionEl.textContent = 'Checking...';
+  chrome.runtime.sendMessage({ type: 'health-check' }, res => {
+    const ok = res?.ok;
+    connectionEl.textContent = ok ? 'Connected' : 'Disconnected';
+    connectionEl.style.color = ok ? '#198754' : '#d93025';
+  });
+}
 
-  const userIdValue = userIdEl.value.trim();
-  const selectedAssignment = assignmentEl.value;
-  const isAddingNewAssignment = selectedAssignment === ADD_NEW_ASSIGNMENT_OPTION;
+async function init() {
+  popupRootEl?.setAttribute('aria-busy', 'true');
 
-  const { valid: userValid, message: userMessage, normalized: normalizedUserId } = validateUserId(userIdValue);
-  if (!userValid) {
-    setError(userMessage);
-    updateSubmitButton();
-    return;
-  }
+  const { environment, userId, appId } = await getSettings();
+  envEl.value = environment;
 
-  isSubmitting = true;
-  updateSubmitButton();
+  if (userId) {
+    state.userIdLocked = true;
+    userIdEl.value = userId;
+    userIdEl.readOnly = true;
+    userIdEl.setAttribute('aria-readonly', 'true');
+    updateUserIdIcons();
+    await loadAppIds(userId, appId);
 
-  try {
-    let savedAppId = formState.fields.appId.saved ? assignmentEl.value : '';
-    if (savedAppId === ADD_NEW_ASSIGNMENT_OPTION) {
-      savedAppId = '';
-    }
-
-    if (!formState.fields.userId.saved) {
-      await saveUserId(normalizedUserId, { appIdForSettings: savedAppId });
-    }
-
-    if (!formState.fields.appId.saved) {
-      if (isAddingNewAssignment) {
-        const { valid, message, normalizedName } = validateAssignmentName(newAssignmentInput?.value ?? '');
-
-        if (!valid) {
-          setAssignmentNameFeedback(message);
-          setError(message);
-          throw new Error(message);
-        }
-
-        const createdAppId = await createNewApp(normalizedName);
-        if (!createdAppId) {
-          ensureAppFieldEditable();
-          return;
-        }
-
-        await saveAppSelection(createdAppId);
-        setStatus('App ID created and saved.');
-      } else if (selectedAssignment) {
-        await saveAppSelection(selectedAssignment);
+    if (appId && Array.from(assignmentEl.options).some(option => option.value === appId)) {
+      lockAppSelection(appId);
+      state.setupComplete = true;
+      setStatus('Setup complete.', false, { persist: true });
+    } else {
+      assignmentEl.disabled = false;
+      state.setupComplete = false;
+      updateAppIdIcons();
+      if (appId) {
+        setError('Saved App ID not found. Please choose another.');
       }
     }
+  } else {
+    state.userIdLocked = false;
+    userIdEl.value = '';
+    userIdEl.readOnly = false;
+    userIdEl.setAttribute('aria-readonly', 'false');
+    updateUserIdIcons();
+    clearAppSelections();
+    setStatus('Enter your User ID to load available App IDs.', false, { persist: true });
+  }
 
-    updateSubmitButton();
-  } catch (error) {
-    console.error('Submit failed', error);
-  } finally {
-    isSubmitting = false;
+  popupRootEl?.setAttribute('aria-busy', 'false');
+  updateSubmitButton();
+  updateConnection();
+}
+
+init();
+
+envEl.addEventListener('change', () => {
+  setError('');
+  state.setupComplete = false;
+  if (state.userIdLocked) {
+    clearAppSelections();
+    loadAppIds(userIdEl.value.trim(), assignmentEl.value);
+  }
+  updateSubmitButton();
+});
+
+userIdEl.addEventListener('input', () => {
+  if (state.userIdLocked) {
+    return;
+  }
+  setError('');
+  setStatus('');
+  clearAppSelections();
+  updateSubmitButton();
+});
+
+userIdEl.addEventListener('keydown', event => {
+  if (event.key === 'Enter' && !state.userIdLocked) {
+    event.preventDefault();
+    const { valid, message, normalized } = validateUserId(userIdEl.value);
+    if (!valid) {
+      setError(message);
+      return;
+    }
+    setError('');
+    setStatus('');
+    lockUserId(normalized);
     updateSubmitButton();
   }
+});
+
+if (userIdSavedIcon) {
+  userIdSavedIcon.setAttribute('role', 'button');
+  userIdSavedIcon.setAttribute('tabindex', '0');
+  userIdSavedIcon.addEventListener('click', handleIconActivation(() => {
+    if (state.userIdLocked) {
+      return;
+    }
+    const { valid, message, normalized } = validateUserId(userIdEl.value);
+    if (!valid) {
+      setError(message);
+      return;
+    }
+    setError('');
+    setStatus('');
+    lockUserId(normalized);
+    updateSubmitButton();
+  }));
+  userIdSavedIcon.addEventListener('keydown', handleIconActivation(() => {
+    if (state.userIdLocked) {
+      return;
+    }
+    const { valid, message, normalized } = validateUserId(userIdEl.value);
+    if (!valid) {
+      setError(message);
+      return;
+    }
+    setError('');
+    setStatus('');
+    lockUserId(normalized);
+    updateSubmitButton();
+  }));
+}
+
+if (userIdEditIcon) {
+  userIdEditIcon.setAttribute('role', 'button');
+  userIdEditIcon.setAttribute('tabindex', '0');
+  userIdEditIcon.addEventListener('click', handleIconActivation(unlockUserId));
+  userIdEditIcon.addEventListener('keydown', handleIconActivation(unlockUserId));
+}
+
+assignmentEl.addEventListener('change', handleAssignmentChange);
+newAssignmentInput?.addEventListener('input', handleNewAssignmentInput);
+
+if (appIdEditIcon) {
+  appIdEditIcon.setAttribute('role', 'button');
+  appIdEditIcon.setAttribute('tabindex', '0');
+  appIdEditIcon.addEventListener('click', handleIconActivation(unlockAppSelection));
+  appIdEditIcon.addEventListener('keydown', handleIconActivation(unlockAppSelection));
+}
+
+submitBtn.addEventListener('click', event => {
+  event.preventDefault();
+  handleSubmit();
 });

--- a/extension/tests/popup.test.js
+++ b/extension/tests/popup.test.js
@@ -60,8 +60,8 @@ describe('popup assignment creation flow', () => {
     mockSetSettings = jest.fn().mockResolvedValue(undefined);
     createdAppId = '';
     mockCreateAssignment = jest.fn().mockImplementation((_baseUrl, payload) => {
-      createdAppId = payload.app_id;
-      return Promise.resolve({ id: 10, name: 'NewApp01', app_id: payload.app_id });
+      createdAppId = payload.appId;
+      return Promise.resolve({ id: 10, name: 'NewApp01', app_id: payload.appId });
     });
     mockFetchUserAppIds = jest
       .fn()
@@ -114,9 +114,9 @@ describe('popup assignment creation flow', () => {
 
     expect(mockCreateAssignment).toHaveBeenCalledTimes(1);
     const [, createPayload] = mockCreateAssignment.mock.calls[0];
-    expect(createPayload).toEqual({ app_id: 'NewApp01', user_id: 'user-123' });
+    expect(createPayload).toEqual({ appId: 'NewApp01', userId: 'user-123' });
 
-    expect(mockFetchUserAppIds).toHaveBeenCalledTimes(2);
+    expect(mockFetchUserAppIds).toHaveBeenCalledTimes(1);
     expect(mockFetchUserAppIds).toHaveBeenLastCalledWith('https://api.example', 'user-123');
 
     expect(mockSetSettings).toHaveBeenCalledWith({


### PR DESCRIPTION
## Summary
- rework the popup UI logic to use a focused lock/select flow for user and app IDs with immediate validation and status feedback
- streamline the assignment creation API helper to accept user/app IDs directly and send a minimal payload
- update extension tests to reflect the simplified assignment payload and new popup behavior

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d4b80f9418832497aaaa445c8c0af3