### PR TITLE
Seed assignment metadata in memory

### DIFF
--- a/backend-v2/app/services/memory.py
+++ b/backend-v2/app/services/memory.py
@@ -51,6 +51,22 @@ class AsyncMemoryService:
         assignment_id = str(uuid.uuid4())
         created_at = datetime.utcnow()
 
+        try:
+            await self.add_memory(
+                user_id=user_id,
+                app_id=app_id,
+                messages=[
+                    {"role": "user", "content": f"Starting work on {app_id}"}
+                ],
+            )
+        except Exception as exc:  # pragma: no cover - network failures
+            logger.error(
+                "Failed to seed assignment memory for user=%s app=%s: %s",
+                user_id,
+                app_id,
+                exc,
+            )
+
         return {
             "id": assignment_id,
             "app_id": app_id,


### PR DESCRIPTION
## Summary
- seed a minimal user message when creating an assignment so the app id appears in memory metadata
- add error handling around the initial memory creation attempt

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d4caf5e16c8324b875d0abc07fd05d