### PR TITLE
Condense documentation to validated FastAPI focus

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,7 +1,5 @@
-# Technical Context for Agents
+# Agent Notes
 
-- `AsyncMemoryService` powers GraphMemory search, Graph-enabled assignment seeding, and vocabulary whitelisting so enhancements stay within hard stop sequences and character ceilings.【F:backend-v2/app/services/memory.py†L48-L167】【F:backend-v2/app/services/memory.py†L280-L575】
-- Stop sequences (`\n`, `—`, `•`) and strict char limits are enforced after every OpenAI call, with fallback to the original prompt when guardrails trigger.【F:backend-v2/app/services/memory.py†L494-L575】
-- App-scoped context comes from the Mem0 Entities API plus per-app GraphMemory relations; the service filters relations by `app_id` before building context payloads.【F:backend-v2/app/services/memory.py†L70-L167】【F:backend-v2/app/services/memory.py†L358-L452】
-- Key Pydantic responses: `AssignmentResponse` exposes seeded assignment metadata, while `MemoryResult` captures search hits with optional metadata for the extension UI.【F:backend-v2/app/models.py†L95-L133】
-- Extension code must follow the updated FastAPI contracts used by `background.js` and `api.js`, aligning popup validation with the backend’s `/api/v1/assignments`, `/api/v1/users/{id}/app-ids`, `/api/v1/memories/search`, and `/api/v1/prompts/enhance` routes.【F:extension/background.js†L40-L143】【F:extension/api.js†L5-L99】
+- `Settings` loads `.env`, keeps `DEBUG` false, and requires `MEM0_API_KEY` before imports succeed.【F:backend-v2/app/core/config.py†L8-L24】
+- Startup applies `setup_exception_handlers` ahead of `/api/v1` routers to normalize error payloads.【F:backend-v2/app/main.py†L24-L52】
+- `AsyncMemoryService` enables GraphMemory, instantiates AsyncOpenAI, seeds assignments with `enable_graph=True`, and shares identifier rules with `MemorySearchRequest`.【F:backend-v2/app/services/memory.py†L48-L167】【F:extension/api.js†L69-L109】【F:backend-v2/app/models.py†L68-L88】

--- a/README.md
+++ b/README.md
@@ -1,62 +1,16 @@
-# Master Mind AI – FastAPI Backend v2
+# Master Mind AI FastAPI Stack
 
-Master Mind AI pairs a Chrome extension with a hardened FastAPI backend to deliver context-aware prompt enhancement powered by Mem0 GraphMemory. The `backend-v2/` service is the production path: it runs on Uvicorn, speaks to the Mem0 v2 API, and exposes a lean surface area that keeps the browser extension responsive even on slow networks.
+Master Mind AI links the Chrome extension to a FastAPI backend that uses Mem0 v2 GraphMemory for hardened prompt enhancement.【F:backend-v2/app/main.py†L24-L52】【F:backend-v2/app/services/memory.py†L204-L520】
 
-## Architecture at a Glance
-- **Browser Extension** captures AI conversations, lets users pick an app namespace, and calls the FastAPI service for enhancement and memory search.
-- **FastAPI backend-v2** (`uvicorn backend-v2.app.main:app`) hosts `/api/v1` routes, wraps the hardened `AsyncMemoryService`, and handles CORS for the extension.【F:backend-v2/app/main.py†L24-L49】
-- **Mem0 GraphMemory** is enabled project-wide so every assignment seeds a relationship graph that future enhancement calls can reuse.【F:backend-v2/app/services/memory.py†L48-L116】【F:backend-v2/app/services/memory.py†L254-L358】
-- **OpenAI integration** uses async chat completions with strict vocabulary whitelists and post-processing guardrails to stop hallucinations.【F:backend-v2/app/services/memory.py†L256-L358】【F:backend-v2/app/services/memory.py†L482-L575】
+## Core
+- FastAPI enables extension CORS, mounts `/api/v1` routers, and delegates to `AsyncMemoryService` for GraphMemory seeding, `app_id` filtering, and OpenAI guardrails.【F:backend-v2/app/main.py†L24-L52】【F:backend-v2/app/services/memory.py†L118-L205】【F:backend-v2/app/services/memory.py†L420-L520】
+- The extension enforces ≥3 character app IDs before its retrying client calls the backend.【F:extension/popup.js†L174-L213】【F:extension/api.js†L1-L100】
 
-## Hardened Enhancement System
-`AsyncMemoryService` combines GraphMemory search with multi-layer safety controls:
-- Seeds every assignment with a Mem0 v2 memory so GraphMemory relationships exist before the first enhancement.【F:backend-v2/app/services/memory.py†L118-L167】
-- Searches hierarchically (app scope → user scope → legacy fallback) with GraphMemory enabled wherever possible.【F:backend-v2/app/services/memory.py†L280-L358】
-- Builds a vocabulary whitelist from the prompt and retrieved context, then enforces stop sequences, character ceilings, and post-processing cleanup on the final response.【F:backend-v2/app/services/memory.py†L420-L575】
-- Provides async helpers for Entities API lookups so the extension can discover valid app IDs without extra endpoints.【F:backend-v2/app/services/memory.py†L70-L117】
+## Run
+Copy `env.example` to `.env`, set Mem0 (required) and OpenAI keys for `Settings`, install with `cd backend-v2 && pip install -r requirements.txt`, then launch `uvicorn backend-v2.app.main:app --reload` and point the extension at `http://localhost:8000`.【F:backend-v2/app/core/config.py†L8-L24】【F:backend-v2/requirements.txt†L1-L22】【F:backend-v2/app/main.py†L54-L57】【F:extension/background.js†L40-L143】
 
-## FastAPI Endpoints
-All routes live under `/api/v1` and return Pydantic models:
-- `GET /api/v1/health` → service heartbeat.【F:backend-v2/app/routers/health.py†L13-L22】
-- `GET /api/v1/users/{user_id}/app-ids` → app discovery via Mem0 Entities API (3+ character IDs only).【F:backend-v2/app/routers/users.py†L13-L35】
-- `POST /api/v1/assignments` → create assignment metadata and seed GraphMemory.【F:backend-v2/app/routers/assignments.py†L12-L23】
-- `POST /api/v1/prompts/enhance` → run the hardened enhancement pipeline.【F:backend-v2/app/routers/enhancement.py†L12-L30】
-- `POST /api/v1/memories/search` → query Mem0 with optional app scoping and GraphMemory output.【F:backend-v2/app/routers/memories.py†L15-L44】
+## API
+`GET /api/v1/health` heartbeat.【F:backend-v2/app/routers/health.py†L13-L22】【F:backend-v2/app/models.py†L42-L48】 `GET /api/v1/users/{user_id}/app-ids` filters results to ≥3 characters.【F:backend-v2/app/routers/users.py†L13-L35】【F:backend-v2/app/services/memory.py†L70-L105】 `POST /api/v1/assignments` seeds GraphMemory and returns metadata.【F:backend-v2/app/routers/assignments.py†L13-L24】【F:backend-v2/app/services/memory.py†L118-L167】 `POST /api/v1/prompts/enhance` runs two-stage search plus hardened OpenAI output.【F:backend-v2/app/routers/enhancement.py†L13-L31】【F:backend-v2/app/services/memory.py†L204-L358】 `POST /api/v1/memories/search` performs GraphMemory-aware search with optional app/run filters.【F:backend-v2/app/routers/memories.py†L15-L44】【F:backend-v2/app/services/memory.py†L380-L438】
 
-## Quick Start (FastAPI)
-1. Copy `env.example` to `.env` and fill in Mem0 and OpenAI keys.
-2. Install backend dependencies:
-   ```bash
-   cd backend-v2
-   pip install -r requirements.txt
-   ```
-3. Launch the service:
-   ```bash
-   uvicorn backend-v2.app.main:app --reload
-   ```
-4. Load the extension from `extension/` in Chrome (Developer Mode) and point it at `http://localhost:8000`.
-
-## Environment Variables
-The FastAPI service reads only the following variables (see `backend-v2/app/core/config.py`):
-- `MEM0_API_KEY` – required for Mem0 GraphMemory operations.
-- `OPENAI_API_KEY` – optional; enables hardened enhancement when set.
-Additional extension values (`ENVIRONMENT`, cached IDs) remain in Chrome storage.
-
-## Deployment Notes
-- **Docker**: The root `Dockerfile` installs `backend-v2` dependencies and starts Uvicorn directly. Combine with `docker-compose.yml` to run FastAPI alongside optional services.
-- **Render**: `render*.sh` scripts skip Django commands and boot Uvicorn with the `/api/v1/health` check path so the platform knows the service is ready.
-- **Health checks**: ensure `/api/v1/health` returns HTTP 200 before routing traffic.
-
-## Extension Alignment Checklist
-- Update popup validation to accept app IDs with **three or more** characters so Entities API results load correctly.【F:extension/popup.js†L168-L203】
-- Extension API calls now target `/api/v1/assignments`, `/api/v1/users/{id}/app-ids`, `/api/v1/prompts/enhance`, and `/api/v1/memories/search`; conversation archiving and `/api/debug-logs` are disabled to match the FastAPI backend.【F:extension/api.js†L5-L99】【F:extension/background.js†L40-L102】
-- Background enhancement keeps using stored `user_id`, `app_id`, and optional `run_id`, ensuring prompts always travel through the hardened pipeline.【F:extension/background.js†L103-L143】
-
-## Testing
-- **Backend**: run `pytest` inside `backend-v2/` after configuring `.env` to exercise service modules.
-- **Extension**: run `npm test` inside `extension/` for Jest coverage of popup flows, API client changes, and DOM observers.
-
-## Migration Status
-- Old Django-specific docs (`docs/*.md`) were removed; this README is now the single source of truth.
-- Deployment scripts, environment templates, and extension code paths have been rewritten for the FastAPI/Uvicorn stack.
-
+## Validation
+Hardened enhancement layers hierarchical search, whitelist vocabularies, stop sequences, and truncation fallbacks; Entities API results match the ≥3 character rule enforced by the extension; tests: `pytest` (no suites yet, command completes).【F:backend-v2/app/services/memory.py†L212-L520】【F:backend-v2/app/services/memory.py†L70-L105】【F:extension/popup.js†L194-L213】【406a0e†L1-L7】

--- a/backend-v2/README.md
+++ b/backend-v2/README.md
@@ -1,36 +1,5 @@
-# Master Mind AI FastAPI Service
+# backend-v2 API Notes
 
-This directory contains the experimental FastAPI implementation of the Master Mind AI backend.
-
-## Features
-
-- Lightweight health check endpoint that avoids Mem0 calls
-- User app ID discovery via Mem0
-- Assignment namespace initialisation without a relational database
-- Two-stage prompt enhancement using Mem0 memories and OpenAI chat completions
-- Memory search endpoint that replaces the legacy conversation search
-
-## Getting Started
-
-```bash
-cd backend-v2
-python -m venv .venv
-source .venv/bin/activate
-pip install -r requirements.txt
-export MEM0_API_KEY="your_mem0_key"
-uvicorn app.main:app --reload
-```
-
-Visit `http://localhost:8000/docs` for automatically generated API documentation.
-
-## Environment Variables
-
-- `MEM0_API_KEY` (required): API key for Mem0.
-- `OPENAI_API_KEY` (optional): Forwarded to Mem0 chat completions when set.
-
-## Docker
-
-```bash
-docker build -t mastermind-fastapi .
-docker run -p 8000:8000 -e MEM0_API_KEY=your_key mastermind-fastapi
-```
+`AssignmentCreateRequest` restricts `app_id` to 3–50 characters while seeding GraphMemory metadata; `EnhanceRequest` and `MemorySearchRequest` reuse the relaxed identifier pattern and bound search `limit` to 1–20 for `/memories/search`.【F:backend-v2/app/models.py†L17-L88】【F:backend-v2/app/services/memory.py†L118-L167】【F:backend-v2/app/routers/memories.py†L15-L44】
+Enhancement cleans whitespace, tries app/user/basic searches, filters relations to the requested `app_id`, and applies whitelist plus stop guardrails before emitting `EnhanceResponse`.【F:backend-v2/app/services/memory.py†L232-L520】【F:backend-v2/app/models.py†L34-L41】
+The search helper defaults to Mem0 v2 GraphMemory, mirrors optional `app_id`/`run_id` filters from the extension, and falls back to v1 if needed.【F:backend-v2/app/services/memory.py†L380-L438】【F:extension/api.js†L69-L109】


### PR DESCRIPTION
## Summary
- compress root README into a verified FastAPI overview with endpoint validation notes under 4K characters
- replace backend-v2 README with API contract details focused on current request models and search behavior
- refresh CONTEXT agent notes to highlight configuration, exception wiring, and shared identifier rules

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d8a5e257408324b4ccf03b02d638e5